### PR TITLE
Autenticación de proveedores post inicio de Auth.Server

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,6 +1,6 @@
 name: Elixir CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-elixir@v1
       with:
         elixir-version: 1.9.4 # Define the elixir version [required]
         otp-version: 22.2 # Define the OTP version [required]

--- a/lib/auth/server.ex
+++ b/lib/auth/server.ex
@@ -5,47 +5,25 @@ defmodule Whatsapp.Auth.Server do
 
   # Every 24 hours
   @daily 24 * 60 * 60 * 1_000
-  @server WhatsappAuthServer
+  @server __MODULE__
 
   require Logger
 
   use GenServer
 
-  alias __MODULE__
   alias Whatsapp.Auth.Manager
   alias Whatsapp.Models.WhatsappProvider
 
   @doc """
-  Callback de inicio del GenServer
+  Carga la configuración de los providers dados y los autentica
   """
-  @spec init(Keyword.t()) :: {:ok, any()}
-  def init(args) do
-    Process.flag(:trap_exit, true)
-    Logger.info("Whatsapp Auth System online")
-
-    providers =
-      args
-      |> Keyword.fetch!(:providers)
-      |> _remove_invalid_providers()
-      |> Enum.map(&struct(WhatsappProvider, &1))
-
-    schedule_token_check()
-
-    {
-      :ok,
-      %{
-        tokens: get_tokens_info(providers),
-        providers: providers
-      }
-    }
+  @spec load_config(map() | [map()]) :: :ok
+  def load_config(config) when is_map(config) do
+    load_config([config])
   end
 
-  @doc """
-  Inicia el GenServer para manejo de la autenticación de Whatsapp
-  """
-  @spec start_link(list) :: any()
-  def start_link(providers) do
-    GenServer.start_link(Server, [providers: providers], name: @server)
+  def load_config([_ | _] = config) do
+    GenServer.cast(@server, {:load_providers_config, config})
   end
 
   @doc """
@@ -65,10 +43,31 @@ defmodule Whatsapp.Auth.Server do
   end
 
   @doc """
+  Inicia el GenServer para manejo de la autenticación de Whatsapp
+  """
+  @spec start_link(list) :: any()
+  def start_link(providers \\ []) do
+    GenServer.start_link(@server, providers, name: @server)
+  end
+
+  @doc """
+  Callback de inicio del GenServer
+  """
+  @impl true
+  def init(providers) do
+    Process.flag(:trap_exit, true)
+    Logger.info("Whatsapp Auth System online")
+
+    schedule_token_check()
+
+    {:ok, do_load_config(providers)}
+  end
+
+  @doc """
   Callback al terminar el GenServer. Hace logout de todos los servicios de
   Whatsapp guardados
   """
-  @spec terminate(atom, map) :: any()
+  @impl true
   def terminate(_reason, state) do
     state.providers
     |> Enum.reduce(%{}, fn provider, tokens ->
@@ -81,11 +80,7 @@ defmodule Whatsapp.Auth.Server do
     end)
   end
 
-  @doc """
-  Handler del GenServer para la llamada asincrona
-  tipo info para token check diario
-  """
-  @spec handle_info(:token_check, any()) :: {:noreply, any()}
+  @impl true
   def handle_info(:token_check, %{providers: providers} = state) do
     Logger.info("Checking tokens")
     tokens = update_expired_tokens(providers)
@@ -93,22 +88,65 @@ defmodule Whatsapp.Auth.Server do
     {:noreply, Map.put(state, :tokens, tokens)}
   end
 
-  @doc """
-  Lista los tokens guardados
-  """
-  @spec handle_call(:list, PID, map) :: {:reply, map, map}
+  @impl true
   def handle_call(:list, _from, state) do
     {:reply, state, state}
   end
 
-  @doc """
-  Handler del GenServer para llamada sincrona para
-  obtener el token de un producto
-  """
-  @spec handle_call({:lookup_token, binary()}, any(), any()) :: {:reply, any(), any()}
+  @impl true
   def handle_call({:lookup_token, product}, _from, state) do
     %{"token" => token, "url" => url} = Map.get(state.tokens, product)
     {:reply, {url, get_auth_header(token)}, state}
+  end
+
+  @impl true
+  def handle_cast({:load_providers_config, []}, state) do
+    {:noreply, state}
+  end
+
+  def handle_cast({:load_providers_config, providers}, state) do
+    new_state =
+      case do_load_config(providers) do
+        %{tokens: new_tokens, providers: new_providers} ->
+          state
+          |> Map.update!(:providers, &update_providers(&1, new_providers))
+          |> Map.update!(:tokens, &update_tokens(&1, new_tokens))
+
+        _ ->
+          state
+      end
+
+    {:noreply, new_state}
+  end
+
+  # Actualiza la configuración sólo de los providers que se recibieron
+  @spec update_providers([map()], [map()]) :: [map()]
+  defp update_providers([], new_providers) do
+    new_providers
+  end
+
+  defp update_providers(providers, new_providers) do
+    providers
+    |> Enum.filter(fn %{name: provider_name} ->
+      new_providers
+      |> Enum.find(fn %{name: new_provider_name} -> new_provider_name == provider_name end)
+      |> case do
+        nil ->
+          true
+
+        _ ->
+          false
+      end
+    end)
+    |> Kernel.++(new_providers)
+  end
+
+  # Actualiza los tokens sólo de los providers que se recibieron
+  @spec update_tokens(map(), map()) :: map()
+  defp update_tokens(tokens, new_tokens) do
+    Enum.reduce(new_tokens, tokens, fn {key, new_token}, updated_tokens ->
+      Map.put(updated_tokens, key, new_token)
+    end)
   end
 
   defp get_auth_header(token) do
@@ -122,44 +160,30 @@ defmodule Whatsapp.Auth.Server do
   end
 
   def update_expired_tokens(providers) do
-    Enum.reduce(
-      providers,
-      %{},
-      fn provider, credentials ->
-        credentials_product = Map.get(credentials, provider.name)
-        expires = Map.get(credentials_product, "expires_after")
-        hours_diff = (expires && Timex.diff(expires, Timex.now(), :hours)) || 0
+    Enum.reduce(providers, %{}, fn provider, credentials ->
+      credentials_product = Map.get(credentials, provider.name)
+      expires = Map.get(credentials_product, "expires_after")
+      hours_diff = (expires && Timex.diff(expires, Timex.now(), :hours)) || 0
 
-        credentials = (hours_diff < 24 && Manager.login(provider)) || credentials
+      credentials = (hours_diff < 24 && Manager.login(provider)) || credentials
 
-        Map.put(
-          credentials,
-          provider.name,
-          Map.put(credentials, "url", provider.url)
-        )
-      end
-    )
+      Map.put(credentials, provider.name, Map.put(credentials, "url", provider.url))
+    end)
   end
 
   def get_tokens_info(providers) do
-    Enum.reduce(
-      providers,
-      %{},
-      fn provider, credentials ->
-        credentials_provider =
-          provider
-          |> Manager.login()
-          |> Map.put("url", provider.url)
+    Enum.reduce(providers, %{}, fn provider, credentials ->
+      credentials_provider =
+        provider
+        |> Manager.login()
+        |> Map.put("url", provider.url)
 
-        Map.put(
-          credentials,
-          provider.name,
-          credentials_provider
-        )
-      end
-    )
+      Map.put(credentials, provider.name, credentials_provider)
+    end)
   end
 
+  # Remueve las configuraciones inválidas de providers
+  @spec _remove_invalid_providers([map()]) :: [map()]
   defp _remove_invalid_providers([]), do: []
 
   defp _remove_invalid_providers([%{username: nil} | tail]) do
@@ -172,5 +196,25 @@ defmodule Whatsapp.Auth.Server do
 
   defp _remove_invalid_providers([provider | tail]) do
     [provider | _remove_invalid_providers(tail)]
+  end
+
+  # Carga la configuración de los providers dados. Esto incluye
+  # hacer login para obtener el token de cada uno
+  @spec do_load_config([map()]) :: map()
+  defp do_load_config([]) do
+    Logger.info(fn -> "No Whatsapp Configs loaded" end)
+    %{tokens: %{}, providers: []}
+  end
+
+  defp do_load_config(providers) do
+    providers =
+      providers
+      |> _remove_invalid_providers()
+      |> Enum.map(&struct(WhatsappProvider, &1))
+
+    %{
+      tokens: get_tokens_info(providers),
+      providers: providers
+    }
   end
 end

--- a/lib/auth/server.ex
+++ b/lib/auth/server.ex
@@ -128,9 +128,7 @@ defmodule Whatsapp.Auth.Server do
   defp update_providers(providers, new_providers) do
     providers
     |> Enum.filter(fn %{name: provider_name} ->
-      new_providers
-      |> Enum.find(fn %{name: new_provider_name} -> new_provider_name == provider_name end)
-      |> case do
+      case Enum.find(new_providers, &(&1.name == provider_name)) do
         nil ->
           true
 
@@ -144,9 +142,7 @@ defmodule Whatsapp.Auth.Server do
   # Actualiza los tokens sólo de los providers que se recibieron
   @spec update_tokens(map(), map()) :: map()
   defp update_tokens(tokens, new_tokens) do
-    Enum.reduce(new_tokens, tokens, fn {key, new_token}, updated_tokens ->
-      Map.put(updated_tokens, key, new_token)
-    end)
+    Map.merge(tokens, new_tokens)
   end
 
   defp get_auth_header(token) do

--- a/test/auth/server_test.exs
+++ b/test/auth/server_test.exs
@@ -48,4 +48,55 @@ defmodule Whatsapp.Auth.ServerTest do
       assert auth_header == {"Authorization", "Bearer dXNlcm5hbWU6cGFzc3dvcmQ="}
     end
   end
+
+  test "Should be able to load provider configs after start" do
+    with_mocks([
+      {
+        WhatsappApiRequest,
+        [],
+        [
+          post!: fn _, _, _ ->
+            %HTTPoison.Response{
+              body: %{
+                "users" => [
+                  %{
+                    "token" => "dXNlcm5hbWU6cGFzc3dvcmQ=",
+                    "expires_after" => "2018-03-01 15:29:26+00:00"
+                  }
+                ]
+              }
+            }
+          end
+        ]
+      }
+    ]) do
+      providers = [
+        %{
+          name: "My company",
+          username: "username",
+          password: "password",
+          url: "https://wa.io:9090/v1"
+        },
+        %{
+          name: "Whatsapp ES",
+          username: "user_es",
+          password: "pwd_ws",
+          url: "https://wa.es.io:9090/v1"
+        }
+      ]
+
+      {:ok, _pid} = Server.start_link()
+      :ok = Server.load_config(providers)
+
+      {url, auth_header} = Server.get_token_info("My company")
+
+      assert url == "https://wa.io:9090/v1"
+      assert auth_header == {"Authorization", "Bearer dXNlcm5hbWU6cGFzc3dvcmQ="}
+
+      {url, auth_header} = Server.get_token_info("Whatsapp ES")
+
+      assert url == "https://wa.es.io:9090/v1"
+      assert auth_header == {"Authorization", "Bearer dXNlcm5hbWU6cGFzc3dvcmQ="}
+    end
+  end
 end


### PR DESCRIPTION
Agrega logica para poder cargar configuraciones para proveedores de Whatsapp despues de que el server de Auth haya iniciado. Asi como poder iniciar el Auth.Server sin necesidad de tener providers cargados.