### PR TITLE
Login rescue

### DIFF
--- a/lib/auth/server.ex
+++ b/lib/auth/server.ex
@@ -179,7 +179,7 @@ defmodule Whatsapp.Auth.Server do
       rescue
         error ->
           previous_errors = Map.get(credentials, :errors, [])
-          errors = [%{provider.name => inspect(error)} | previous_errors]
+          errors = [{provider.name, inspect(error)} | previous_errors]
           Map.put(credentials, :errors, errors)
       end
     end)


### PR DESCRIPTION
Esto evita que si algun login a un servidor de Whatsapp mate el genserver de Auth. 
El genserver guarda el error en el state y tiene soporte para multiples errores (por si varios servidores no responden)

Ejemplo:

```elixir
%{
  providers: [
    %Whatsapp.Models.WhatsappProvider{
      name: "rtd-mx-test",
      password: "password",
      url: "https://wa.resuelve.test/v1",
      username: "username"
    },
    %Whatsapp.Models.WhatsappProvider{
      name: "rtd-es-test",
      password: "pwd_ws",
      url: "https://wa.es.resuelve.test:9090/v1",
      username: "user_es"
    }
  ],
  tokens: %{
    errors: [
      {"rtd-es-test", "%HTTPoison.Error{id: nil, reason: :nxdomain}"},
      {"rtd-mx-test", "%HTTPoison.Error{id: nil, reason: :nxdomain}"}
    ]
  }
}
```

### Nota
Esto es un hotfix, deberá en un futuro atacarse este manejo de tokens de mejor manera de lo que se hace actualmente.