### PR TITLE
Migrar envio de mensajes con imagenes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,5 +31,6 @@ import Config
 
 config :wax, parser: Whatsapp.Parser
 
-config :wax,
-  cloud_api_url: "https://graph.facebook.com/v23.0/"
+config :wax, :cloud_api,
+  url: "https://graph.facebook.com",
+  api_version: "v23.0"

--- a/lib/cloud_api.ex
+++ b/lib/cloud_api.ex
@@ -1,0 +1,19 @@
+defmodule Wax.CloudAPI do
+  @moduledoc """
+  Whatsapp Cloud API
+  """
+
+  @doc """
+  Builds a URL for a Cloud API number and endpoint
+  """
+  @spec build_url(String.t(), String.t()) :: String.t()
+  def build_url(whatsapp_number_id, endpoint) do
+    config = Application.get_env(:wax, :cloud_api)
+    url = config[:url]
+    api_version = config[:api_version]
+
+    url
+    |> URI.merge("#{api_version}/#{whatsapp_number_id}/#{endpoint}")
+    |> URI.to_string()
+  end
+end

--- a/lib/cloud_api/auth.ex
+++ b/lib/cloud_api/auth.ex
@@ -25,4 +25,12 @@ defmodule Wax.CloudAPI.Auth do
       token: token
     }
   end
+
+  @doc """
+  Builds the Authorization header the Cloud API requires
+  """
+  @spec build_header(__MODULE__.t()) :: {String.t(), bearer_token :: String.t()}
+  def build_header(%__MODULE__{} = auth) do
+    {"Authorization", "Bearer " <> auth.token}
+  end
 end

--- a/lib/cloud_api/media.ex
+++ b/lib/cloud_api/media.ex
@@ -1,0 +1,39 @@
+defmodule Wax.CloudAPI.Media do
+  @moduledoc """
+  Media managment via the Cloud API
+  """
+
+  alias Wax.CloudAPI
+  alias Wax.CloudAPI.{Auth, ResponseParser}
+
+  @doc """
+  Uploads an image to the Cloud API servers
+
+  This returns the Media ID, which is required to send any type
+  of media files in a message.
+
+  """
+  @spec upload(Path.t(), Auth.t()) ::
+          {:ok, media_id :: String.t()} | {:error, String.t()}
+  def upload(file_path, %Auth{} = auth) do
+    mime_type = MIME.from_path(file_path)
+    headers = [Auth.build_header(auth)]
+
+    data = [
+      {:file, file_path},
+      {"type", mime_type},
+      {"messaging_product", "whatsapp"}
+    ]
+
+    auth.whatsapp_number_id
+    |> CloudAPI.build_url("media")
+    |> HTTPoison.post({:multipart, data}, headers)
+    |> case do
+      {:ok, response} ->
+        ResponseParser.parse(response, :media_upload)
+
+      _ ->
+        {:error, "Media upload failed"}
+    end
+  end
+end

--- a/lib/cloud_api/messages.ex
+++ b/lib/cloud_api/messages.ex
@@ -5,6 +5,7 @@ defmodule Wax.CloudAPI.Messages do
   You can send different types of messages using send/2
   """
 
+  alias Wax.CloudAPI
   alias Wax.CloudAPI.{Auth, ResponseParser}
   alias Wax.Messages.Message
 
@@ -13,10 +14,8 @@ defmodule Wax.CloudAPI.Messages do
     with :ok <- Message.validate(message) do
       headers = [{"Authorization", "Bearer " <> auth.token}]
 
-      :wax
-      |> Application.get_env(:cloud_api_url)
-      |> URI.merge("/#{auth.whatsapp_number_id}/messages")
-      |> URI.to_string()
+      auth.whatsapp_number_id
+      |> CloudAPI.build_url("messages")
       |> WhatsappApiRequest.rate_limit_request(:post!, message, headers)
       |> ResponseParser.parse(:messages_send)
     end

--- a/lib/cloud_api/response_parser.ex
+++ b/lib/cloud_api/response_parser.ex
@@ -10,6 +10,16 @@ defmodule Wax.CloudAPI.ResponseParser do
 
   TODO: Implement a WhatsappResponse struct
   """
+  def parse(%Response{status_code: 200, body: body}, :media_upload) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, %{"id" => media_id}} ->
+        {:ok, media_id}
+
+      _ ->
+        {:error, "Media ID not found in response: #{body}"}
+    end
+  end
+
   def parse(%Response{status_code: 200, body: body}, _type) do
     {:ok, body}
   end

--- a/lib/messages/media.ex
+++ b/lib/messages/media.ex
@@ -1,4 +1,26 @@
 defmodule Wax.Messages.Media do
-  @type t :: %__MODULE__{}
-  defstruct []
+  @moduledoc """
+  The Whatsapp Message Media Object
+
+  ## Fields
+
+  - id: The media object ID
+  - link: The protocol and URL of the media to be sent
+  - caption: Media asset caption
+  - filename: Describes the filename for the specific document
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          caption: String.t()
+        }
+
+  @fields_to_encode ~w(id caption)a
+
+  @derive {Jason.Encoder, only: @fields_to_encode}
+  defstruct [
+    :id,
+    :caption
+  ]
 end

--- a/lib/messages/message.ex
+++ b/lib/messages/message.ex
@@ -18,6 +18,8 @@ defmodule Wax.Messages.Message do
 
   @message_types [:contact, :document, :image, :interactive, :location, :template, :text]
 
+  @typep whatsapp_media_id :: String.t()
+
   @typep message_type ::
            :contact | :document | :image | :interactive | :location | :template | :text
 
@@ -91,7 +93,7 @@ defmodule Wax.Messages.Message do
   end
 
   @doc """
-  Checks if a message is valid to be sent to the Cloud API
+  Adds a text object to the message
   """
   @spec set_text(__MODULE__.t(), String.t()) :: __MODULE__.t()
   def set_text(%__MODULE__{} = message, body, preview_url \\ false) do
@@ -99,6 +101,23 @@ defmodule Wax.Messages.Message do
     %{message | text: text}
   end
 
+  @doc """
+  Adds an image object to the message
+
+  Images also accept a text caption to be sent together with it
+  """
+  @spec add_image(__MODULE__.t(), whatsapp_media_id(), String.t() | nil) :: __MODULE__.t()
+  def add_image(%__MODULE__{} = message, media_id, caption \\ nil) do
+    media = %Media{id: media_id, caption: caption}
+
+    %{message | image: media}
+  end
+
+  @doc """
+  Validates a message
+
+  Checks if a message is valid to be sent to the Cloud API
+  """
   @spec validate(__MODULE__.t()) :: :ok | {:error, String.t()}
   def validate(%__MODULE__{to: to}) when to in ["", nil] do
     {:error, "Missing recipient number of message"}
@@ -114,6 +133,16 @@ defmodule Wax.Messages.Message do
 
       _ ->
         {:error, "Text field is required"}
+    end
+  end
+
+  def validate(%__MODULE__{type: :image} = message) do
+    case message.image do
+      %Media{id: id} when is_binary(id) ->
+        :ok
+
+      _ ->
+        {:error, "Media field is required"}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,8 @@ defmodule WhatsappApi.MixProject do
       {:timex, "~> 3.7"},
       {:jason, "~> 1.4.4"},
       {:ex_rated, "~> 2.1.0"},
-      {:bypass, "~> 2.1", only: :test}
+      {:bypass, "~> 2.1", only: :test},
+      {:briefly, "~> 0.5.1", only: :test}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,8 @@ defmodule WhatsappApi.MixProject do
       {:jason, "~> 1.4.4"},
       {:ex_rated, "~> 2.1.0"},
       {:bypass, "~> 2.1", only: :test},
-      {:briefly, "~> 0.5.1", only: :test}
+      {:briefly, "~> 0.5.1", only: :test},
+      {:mime, "~> 2.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "briefly": {:hex, :briefly, "0.5.1", "ee10d48da7f79ed2aebdc3e536d5f9a0c3e36ff76c0ad0d4254653a152b13a8a", [:mix], [], "hexpm", "bd684aa92ad8b7b4e0d92c31200993c4bc1469fc68cd6d5f15144041bd15cb57"},
   "bypass": {:hex, :bypass, "2.1.0", "909782781bf8e20ee86a9cabde36b259d44af8b9f38756173e8f5e2e1fabb9b1", [:mix], [{:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 2.0", [hex: :plug_cowboy, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "d9b5df8fa5b7a6efa08384e9bbecfe4ce61c77d28a4282f79e02f1ef78d96b80"},
   "certifi": {:hex, :certifi, "2.15.0", "0e6e882fcdaaa0a5a9f2b3db55b1394dba07e8d6d9bcad08318fb604c6839712", [:rebar3], [], "hexpm", "b147ed22ce71d72eafdad94f055165c1c182f61a2ff49df28bcc71d1d5b94a60"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm", "1b1dbc1790073076580d0d1d64e42eae2366583e7aecd455d1215b0d16f2451b"},

--- a/test/cloud_api/messages_test.exs
+++ b/test/cloud_api/messages_test.exs
@@ -1,32 +1,31 @@
 defmodule Wax.CloudAPI.MessagesTest do
   use Whatsapp.Case
 
-  alias Wax.CloudAPI.{Auth, Messages}
+  alias Wax.CloudAPI.{Auth, Media, Messages}
   alias Wax.Messages.Message
 
   setup do
     bypass = Bypass.open()
-    Application.put_env(:wax, :cloud_api_url, "http://localhost:#{bypass.port}")
+    Application.put_env(:wax, :cloud_api, url: "http://localhost:#{bypass.port}", version: "")
 
+    test_to_number = "TEST550000000001"
     test_wa_number_id = "TEST0000000001"
     test_token = "TESTTOKEN999"
 
     auth = Auth.new(test_wa_number_id, test_token)
 
-    {:ok, bypass: bypass, auth: auth}
+    {:ok, bypass: bypass, auth: auth, to: test_to_number}
   end
 
   describe "Text messages" do
-    test "Send a text message", %{bypass: bypass, auth: auth} do
-      test_to_number = "TEST550000000001"
-
+    test "Send a text message", %{bypass: bypass, auth: auth, to: to} do
       Bypass.expect_once(bypass, "POST", "/#{auth.whatsapp_number_id}/messages", fn conn ->
         response = ~s<{"messaging_product": "whatsapp", "messages": [{"id": "TESTMESSAGEID"}]}>
         Plug.Conn.resp(conn, 200, response)
       end)
 
       message =
-        test_to_number
+        to
         |> Message.new()
         |> Message.set_type(:text)
         |> Message.set_text("Text message test")
@@ -34,22 +33,18 @@ defmodule Wax.CloudAPI.MessagesTest do
       assert {:ok, %{"messages" => [%{"id" => "TESTMESSAGEID"}]}} = Messages.send(message, auth)
     end
 
-    test "Cannot send a text message with no text", %{auth: auth} do
-      test_to_number = "TEST550000000001"
-
+    test "Cannot send a text message with no text", %{auth: auth, to: to} do
       message =
-        test_to_number
+        to
         |> Message.new()
         |> Message.set_type(:text)
 
       assert {:error, _error} = Messages.send(message, auth)
     end
 
-    test "Cannot send a text message with an empty string", %{auth: auth} do
-      test_to_number = "TEST550000000001"
-
+    test "Cannot send a text message with an empty string", %{auth: auth, to: to} do
       message =
-        test_to_number
+        to
         |> Message.new()
         |> Message.set_type(:text)
         |> Message.set_text("")
@@ -58,12 +53,44 @@ defmodule Wax.CloudAPI.MessagesTest do
     end
   end
 
-  describe "Various errors" do
-    test "Sending a message of an unsupported type", %{auth: auth} do
-      test_to_number = "TEST550000000001"
+  describe "Image messages" do
+    test "Send an image message", %{bypass: bypass, auth: auth, to: to} do
+      Bypass.expect_once(bypass, "POST", "/#{auth.whatsapp_number_id}/media", fn conn ->
+        response = ~s<{"id": "TEST00000000"}>
+        Plug.Conn.resp(conn, 200, response)
+      end)
+
+      {:ok, media_id} =
+        [extname: "png"]
+        |> Briefly.create!()
+        |> Media.upload(auth)
+
+      Bypass.expect(bypass, "POST", "/#{auth.whatsapp_number_id}/messages", fn conn ->
+        response = ~s<{"messaging_product": "whatsapp", "messages": [{"id": "TESTMESSAGEID"}]}>
+        Plug.Conn.resp(conn, 200, response)
+      end)
 
       message =
-        test_to_number
+        to
+        |> Message.new()
+        |> Message.set_type(:image)
+
+      message_with_caption = Message.add_image(message, media_id, "Test caption")
+
+      assert {:ok, %{"messages" => [%{"id" => "TESTMESSAGEID"}]}} =
+               Messages.send(message_with_caption, auth)
+
+      message_no_caption = Message.add_image(message, media_id)
+
+      assert {:ok, %{"messages" => [%{"id" => "TESTMESSAGEID"}]}} =
+               Messages.send(message_no_caption, auth)
+    end
+  end
+
+  describe "Various errors" do
+    test "Sending a message of an unsupported type", %{auth: auth, to: to} do
+      message =
+        to
         |> Message.new()
         |> Message.set_type(:contact)
         |> Message.set_text("")


### PR DESCRIPTION
## Contexto

Necesitamos migrar el envío de mensajes con imágenes para la nueva Cloud API.

## Changelog

### Carga de archivos media

Los archivos media se deben de cargar a Cloud API para poder envíarlos vía mensajes.

Se agregó el módulo `Wax.CloudAPI.Media` y la función `upload/2` para poder cargar archivos media.

```elixir
auth = Auth.new("WHATSAPP_NUMBER_ID", "WHATSAPP_TOKEN")

iex> Wax.CloudAPI.Media.upload("file/path.png", auth)
{:ok, "SOME_MEDIA_ID"}
```

### Envío de mensajes con imágenes

Con el archivo media cargado ahora podemos enviar un mensaje con una imagen usando `Wax.CloudAPI.Messages.send/2`

```elixir
{:ok, media_id} = Wax.CloudAPI.Media.upload("file/path.png", auth)

message = 
  "55000000000"
  |> Message.new()
  |> Message.set_type(:image)
  |> Message.add_image(media_id, "This is a caption")

auth = Auth.new("WHATSAPP_NUMBER_ID", "WHATSAPP_TOKEN")

iex> Messages.send(message, auth)
:ok
```