### PR TITLE
Migrar envío de mensajes con videos

### DIFF
--- a/lib/messages/message.ex
+++ b/lib/messages/message.ex
@@ -118,7 +118,7 @@ defmodule Wax.Messages.Message do
   end
 
   @doc """
-  Adds an video object to the message
+  Adds a video object to the message
 
   Videos also accept a text caption that can be added on the same message
   """

--- a/lib/mix/tasks/send_message.ex
+++ b/lib/mix/tasks/send_message.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.SendMessage do
 
   use Mix.Task
 
-  @media_message_types ~w(image)
+  @media_message_types ~w(image video)
 
   @requirements ["app.start"]
 
@@ -110,6 +110,12 @@ defmodule Mix.Tasks.SendMessage do
     message
     |> Message.set_type(:image)
     |> Message.add_image(media_id, "This is a caption")
+  end
+
+  defp build_test_message(message, "video", %{media_id: media_id}) do
+    message
+    |> Message.set_type(:video)
+    |> Message.add_video(media_id, "This is a video caption")
   end
 
   defp build_test_message(_message, message_type, _params) do

--- a/test/cloud_api/messages_test.exs
+++ b/test/cloud_api/messages_test.exs
@@ -87,6 +87,40 @@ defmodule Wax.CloudAPI.MessagesTest do
     end
   end
 
+  describe "Video messages" do
+    test "Send an video message", %{bypass: bypass, auth: auth, to: to} do
+      Bypass.expect_once(bypass, "POST", "/#{auth.whatsapp_number_id}/media", fn conn ->
+        response = ~s<{"id": "TEST00000000"}>
+        Plug.Conn.resp(conn, 200, response)
+      end)
+
+      {:ok, media_id} =
+        [extname: "mp4"]
+        |> Briefly.create!()
+        |> Media.upload(auth)
+
+      Bypass.expect(bypass, "POST", "/#{auth.whatsapp_number_id}/messages", fn conn ->
+        response = ~s<{"messaging_product": "whatsapp", "messages": [{"id": "TESTMESSAGEID"}]}>
+        Plug.Conn.resp(conn, 200, response)
+      end)
+
+      message =
+        to
+        |> Message.new()
+        |> Message.set_type(:video)
+
+      message_with_caption = Message.add_video(message, media_id, "Test caption")
+
+      assert {:ok, %{"messages" => [%{"id" => "TESTMESSAGEID"}]}} =
+               Messages.send(message_with_caption, auth)
+
+      message_no_caption = Message.add_video(message, media_id)
+
+      assert {:ok, %{"messages" => [%{"id" => "TESTMESSAGEID"}]}} =
+               Messages.send(message_no_caption, auth)
+    end
+  end
+
   describe "Various errors" do
     test "Sending a message of an unsupported type", %{auth: auth, to: to} do
       message =


### PR DESCRIPTION
## Contexto

Necesitamos migrar el envío de mensajes con videos para la nueva Cloud API.

## Changelog

### Envío de mensajes con videos

Con el archivo media cargado ahora podemos enviar un mensaje con un video usando `Wax.CloudAPI.Messages.send/2`

```elixir
{:ok, media_id} = Wax.CloudAPI.Media.upload("file/path.mp4", auth)

message = 
  "55000000000"
  |> Message.new()
  |> Message.set_type(:video)
  |> Message.add_video(media_id, "This is a caption")

auth = Auth.new("WHATSAPP_NUMBER_ID", "WHATSAPP_TOKEN")

iex> Messages.send(message, auth)
:ok
```

![image](https://github.com/user-attachments/assets/a10d745a-4426-4dea-a86f-52d03a1d04ae)