### PR TITLE
Migrar envio de mensajes con audios

### DIFF
--- a/lib/messages/message.ex
+++ b/lib/messages/message.ex
@@ -127,7 +127,7 @@ defmodule Wax.Messages.Message do
   """
   @spec add_image(__MODULE__.t(), whatsapp_media_id(), String.t() | nil) :: __MODULE__.t()
   def add_image(%__MODULE__{} = message, media_id, caption \\ nil) do
-    media = %Media{id: media_id, caption: caption}
+    media = %Media{id: media_id, caption: caption, type: :image}
 
     %{message | image: media}
   end
@@ -139,7 +139,7 @@ defmodule Wax.Messages.Message do
   """
   @spec add_video(__MODULE__.t(), whatsapp_media_id(), String.t() | nil) :: __MODULE__.t()
   def add_video(%__MODULE__{} = message, media_id, caption \\ nil) do
-    media = %Media{id: media_id, caption: caption}
+    media = %Media{id: media_id, caption: caption, type: :video}
 
     %{message | video: media}
   end

--- a/lib/messages/message.ex
+++ b/lib/messages/message.ex
@@ -145,6 +145,16 @@ defmodule Wax.Messages.Message do
   end
 
   @doc """
+  Adds an audio object to the message
+  """
+  @spec add_audio(__MODULE__.t(), whatsapp_media_id()) :: __MODULE__.t()
+  def add_audio(%__MODULE__{} = message, media_id) do
+    media = %Media{id: media_id, type: :audio}
+
+    %{message | audio: media}
+  end
+
+  @doc """
   Validates a message
 
   Checks if a message is valid to be sent to the Cloud API
@@ -177,8 +187,16 @@ defmodule Wax.Messages.Message do
     end
   end
 
+  def validate(%__MODULE__{type: :audio, audio: %Media{id: id}}) when is_binary(id) do
+    :ok
+  end
+
   def validate(%__MODULE__{type: :video, video: %Media{id: id}}) when is_binary(id) do
     :ok
+  end
+
+  def validate(%__MODULE__{type: :audio}) do
+    {:error, "Audio field is required. Use add_audio/3 to add one."}
   end
 
   def validate(%__MODULE__{type: :video}) do

--- a/lib/messages/message.ex
+++ b/lib/messages/message.ex
@@ -19,7 +19,12 @@ defmodule Wax.Messages.Message do
   @typep whatsapp_media_id :: String.t()
 
   @typep message_type ::
-           :contact | :document | :image | :interactive | :location | :template | :text | :video
+           :contact
+           | :interactive
+           | :location
+           | :template
+           | :text
+           | Media.media_type()
 
   @typep whatsapp_id :: String.t()
 

--- a/lib/messages/message.ex
+++ b/lib/messages/message.ex
@@ -42,28 +42,18 @@ defmodule Wax.Messages.Message do
           video: Media.t()
         }
 
-  @message_types [:contact, :document, :image, :interactive, :location, :template, :text, :video]
-
-  @fields_to_encode [
+  @message_types [
     :audio,
-    :contacts,
-    :context,
+    :contact,
     :document,
     :image,
     :interactive,
     :location,
-    :messaging_product,
-    :preview_url,
-    :recipient_type,
-    :status,
     :template,
     :text,
-    :to,
-    :type,
     :video
   ]
 
-  @derive {Jason.Encoder, only: @fields_to_encode}
   defstruct audio: nil,
             contacts: [],
             context: nil,
@@ -80,6 +70,26 @@ defmodule Wax.Messages.Message do
             to: nil,
             type: :text,
             video: nil
+
+  defimpl Jason.Encoder do
+    @base_fields [:messaging_product, :recipient_type, :to, :type]
+
+    def encode(value, opts) do
+      fields = @base_fields
+
+      fields =
+        case Map.get(value, :type) do
+          :audio -> [:audio | fields]
+          :image -> [:image | fields]
+          :video -> [:video | fields]
+          _ -> [:text | fields]
+        end
+
+      value
+      |> Map.take(fields)
+      |> Jason.Encode.map(opts)
+    end
+  end
 
   @doc """
     Creates a new Message structure

--- a/lib/mix/tasks/send_message.ex
+++ b/lib/mix/tasks/send_message.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.SendMessage do
 
   use Mix.Task
 
-  @media_message_types ~w(image video)
+  @media_message_types ~w(audio image video)
 
   @requirements ["app.start"]
 
@@ -116,6 +116,12 @@ defmodule Mix.Tasks.SendMessage do
     message
     |> Message.set_type(:video)
     |> Message.add_video(media_id, "This is a video caption")
+  end
+
+  defp build_test_message(message, "audio", %{media_id: media_id}) do
+    message
+    |> Message.set_type(:audio)
+    |> Message.add_audio(media_id)
   end
 
   defp build_test_message(_message, message_type, _params) do

--- a/test/cloud_api/messages_test.exs
+++ b/test/cloud_api/messages_test.exs
@@ -121,6 +121,33 @@ defmodule Wax.CloudAPI.MessagesTest do
     end
   end
 
+  describe "Audio messages" do
+    test "Send an audio message", %{bypass: bypass, auth: auth, to: to} do
+      Bypass.expect_once(bypass, "POST", "/#{auth.whatsapp_number_id}/media", fn conn ->
+        response = ~s<{"id": "TEST00000000"}>
+        Plug.Conn.resp(conn, 200, response)
+      end)
+
+      {:ok, media_id} =
+        [extname: "mp3"]
+        |> Briefly.create!()
+        |> Media.upload(auth)
+
+      Bypass.expect(bypass, "POST", "/#{auth.whatsapp_number_id}/messages", fn conn ->
+        response = ~s<{"messaging_product": "whatsapp", "messages": [{"id": "TESTMESSAGEID"}]}>
+        Plug.Conn.resp(conn, 200, response)
+      end)
+
+      message =
+        to
+        |> Message.new()
+        |> Message.set_type(:audio)
+        |> Message.add_audio(message, media_id)
+
+      assert {:ok, %{"messages" => [%{"id" => "TESTMESSAGEID"}]}} = Messages.send(message, auth)
+    end
+  end
+
   describe "Various errors" do
     test "Sending a message of an unsupported type", %{auth: auth, to: to} do
       message =


### PR DESCRIPTION
## Contexto

Necesitamos migrar el envío de mensajes con audios para la nueva Cloud API.

## Changelog

### JSON Encoders personalizados

La nueva CloudAPI rechaza peticiones que contiene campos extras para ciertos tipos de mensajes o tipos de media. Para solucionar esto se agregó una implementación de  `Json.Encoder` tanto para `Wax.Messages.Message` como para `Wax.Messages.Media`. 

Esto nos permite encodear solo los campos que son requeridos por tipo de mensaje o media.

### Envío de mensajes con audio

Con el archivo media cargado ahora podemos enviar un mensaje con un audio usando `Wax.CloudAPI.Messages.send/2`

```elixir
{:ok, media_id} = Wax.CloudAPI.Media.upload("file/path.mp3", auth)

message = 
  "55000000000"
  |> Message.new()
  |> Message.set_type(:audio)
  |> Message.add_audio(media_id)

auth = Auth.new("WHATSAPP_NUMBER_ID", "WHATSAPP_TOKEN")

iex> Messages.send(message, auth)
:ok
```

![image](https://github.com/user-attachments/assets/9c871d20-0a99-426b-9ea5-0360b31c84ab)
