### PR TITLE
Migrar envio de templates

### DIFF
--- a/lib/cloud_api/response_parser.ex
+++ b/lib/cloud_api/response_parser.ex
@@ -24,6 +24,15 @@ defmodule Wax.CloudAPI.ResponseParser do
     {:ok, body}
   end
 
+  def parse(
+        %Response{
+          body: %{"error" => %{"code" => error_code, "error_data" => %{"details" => error}}}
+        },
+        _type
+      ) do
+    {:error, "Cloud API Error #{error_code}: #{error}"}
+  end
+
   def parse(%Response{status_code: status_code, body: body}, _type) do
     {:error, "HTTP Error #{status_code}: #{inspect(body)}"}
   end

--- a/lib/messages/media.ex
+++ b/lib/messages/media.ex
@@ -44,4 +44,12 @@ defmodule Wax.Messages.Media do
       |> Jason.Encode.map(opts)
     end
   end
+
+  @doc """
+  Creates a new Media object of Image type
+  """
+  @spec new_image(String.t(), String.t()) :: __MODULE__.t()
+  def new_image(media_id, caption \\ nil) do
+    %__MODULE__{type: :image, id: media_id, caption: caption}
+  end
 end

--- a/lib/messages/message.ex
+++ b/lib/messages/message.ex
@@ -87,6 +87,7 @@ defmodule Wax.Messages.Message do
           :audio -> [:audio | fields]
           :document -> [:document | fields]
           :image -> [:image | fields]
+          :template -> [:template | fields]
           :video -> [:video | fields]
           _ -> [:text | fields]
         end
@@ -150,9 +151,13 @@ defmodule Wax.Messages.Message do
   """
   @spec add_image(__MODULE__.t(), whatsapp_media_id(), String.t() | nil) :: __MODULE__.t()
   def add_image(%__MODULE__{} = message, media_id, caption \\ nil) do
-    media = %Media{id: media_id, caption: caption, type: :image}
+    media = Media.new_image(media_id, caption)
 
     %{message | image: media}
+  end
+
+  def add_template(%__MODULE__{} = message, %Template{} = template) do
+    %{message | template: template}
   end
 
   @doc """
@@ -212,6 +217,10 @@ defmodule Wax.Messages.Message do
     end
   end
 
+  def validate(%__MODULE__{type: :template, template: %Template{}}) do
+    :ok
+  end
+
   def validate(%__MODULE__{type: :video, video: %Media{id: id}}) when is_binary(id) do
     :ok
   end
@@ -222,6 +231,10 @@ defmodule Wax.Messages.Message do
 
   def validate(%__MODULE__{type: :document}) do
     {:error, "Document field is required. Use add_document/3 to add one."}
+  end
+
+  def validate(%__MODULE__{type: :template}) do
+    {:error, "Template field is required. Use add_template/2 to add one."}
   end
 
   def validate(%__MODULE__{type: :video}) do

--- a/lib/messages/message.ex
+++ b/lib/messages/message.ex
@@ -156,6 +156,10 @@ defmodule Wax.Messages.Message do
     %{message | image: media}
   end
 
+  @doc """
+  Adds a template object to the message
+  """
+  @spec add_template(__MODULE__.t(), Template.t()) :: __MODULE__.t()
   def add_template(%__MODULE__{} = message, %Template{} = template) do
     %{message | template: template}
   end

--- a/lib/messages/template.ex
+++ b/lib/messages/template.ex
@@ -98,10 +98,10 @@ defmodule Wax.Messages.Template do
   - text
 
   """
-  @spec add_button(__MODULE__.t(), Keyword.t()) :: __MODULE__.t()
+  @spec add_button(__MODULE__.t(), atom(), index :: 0..9, Keyword.t()) :: __MODULE__.t()
   def add_button(%__MODULE__{} = template, sub_type, index, [_ | _] = params)
       when index in 0..9 do
-    with :ok <- Component.validate_button_params(sub_type, params) |> dbg(),
+    with :ok <- Component.validate_button_params(sub_type, params),
          [%ButtonParameter{} | _] = params = ButtonParameter.parse(params) do
       button = Component.new_button(sub_type, index, params)
       %{template | components: [button | template.components]}

--- a/lib/messages/template.ex
+++ b/lib/messages/template.ex
@@ -8,7 +8,7 @@ defmodule Wax.Messages.Template do
   @type t :: %__MODULE__{
           name: String.t(),
           language: Language.t(),
-          components: [component()]
+          components: [Component.t()]
         }
 
   @derive {Jason.Encoder, only: [:name, :language, :components]}

--- a/lib/messages/template.ex
+++ b/lib/messages/template.ex
@@ -1,4 +1,113 @@
 defmodule Wax.Messages.Template do
-  @type t :: %__MODULE__{}
-  defstruct []
+  @moduledoc """
+  Whatsapp Template Message structure and management
+  """
+
+  alias Wax.Messages.Templates.{ButtonParameter, Component, Language, Parameter}
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          language: Language.t(),
+          components: [component()]
+        }
+
+  @derive {Jason.Encoder, only: [:name, :language, :components]}
+  defstruct [
+    :name,
+    :language,
+    components: []
+  ]
+
+  @doc """
+  Creates a new Template struct
+
+  Accepts both language and language_locale formats (e.g., en and en_US).
+  """
+  @spec new(String.t(), String.t()) :: __MODULE__.t()
+  def new(name, language_code) do
+    %__MODULE__{
+      name: name,
+      language: Language.new(language_code)
+    }
+  end
+
+  @doc """
+  Adds a header object to the template
+
+  ## Parameters
+
+  These are received as a Keyword list where the key is the parameter type.
+  The accepted parameter types are:
+  - currency
+  - date_time
+  - document
+  - image
+  - text
+  -video
+
+  """
+  @spec add_header(__MODULE__.t(), Keyword.t()) :: __MODULE__.t()
+  def add_header(%__MODULE__{} = template, [_ | _] = params) do
+    case Parameter.parse(params) do
+      [%Parameter{} | _] = params ->
+        header = Component.new_header(params)
+        %{template | components: [header | template.components]}
+
+      {:error, error} ->
+        # We are raising errors for now until token validation is implemented
+        raise error
+    end
+  end
+
+  @doc """
+  Adds a body object to the template
+
+  ## Parameters
+
+  These are received as a Keyword list where the key is the parameter type.
+  The accepted parameter types are:
+  - currency
+  - date_time
+  - document
+  - image
+  - text
+  -video
+
+  """
+  @spec add_body(__MODULE__.t(), Keyword.t()) :: __MODULE__.t()
+  def add_body(%__MODULE__{} = template, [_ | _] = params) do
+    case Parameter.parse(params) do
+      [%Parameter{} | _] = params ->
+        body = Component.new_body(params)
+        %{template | components: [body | template.components]}
+
+      {:error, error} ->
+        # We are raising errors for now until token validation is implemented
+        raise error
+    end
+  end
+
+  @doc """
+  Adds a button object to the template
+
+  ## Parameters
+
+  These are received as a Keyword list where the key is the parameter type.
+  The accepted parameter types are:
+  - payload
+  - text
+
+  """
+  @spec add_button(__MODULE__.t(), Keyword.t()) :: __MODULE__.t()
+  def add_button(%__MODULE__{} = template, sub_type, index, [_ | _] = params)
+      when index in 0..9 do
+    with :ok <- Component.validate_button_params(sub_type, params) |> dbg(),
+         [%ButtonParameter{} | _] = params = ButtonParameter.parse(params) do
+      button = Component.new_button(sub_type, index, params)
+      %{template | components: [button | template.components]}
+    else
+      {:error, error} ->
+        raise error
+    end
+  end
 end

--- a/lib/messages/templates/button_parameter.ex
+++ b/lib/messages/templates/button_parameter.ex
@@ -1,0 +1,59 @@
+defmodule Wax.Messages.Templates.ButtonParameter do
+  @moduledoc """
+  Template button parameter struct
+  """
+
+  @typep parameter_type :: :payload | :text
+  @type t :: %__MODULE__{
+          type: parameter_type(),
+          payload: String.t() | map(),
+          text: String.t()
+        }
+
+  @derive {Jason.Encoder, only: [:type, :payload, :text]}
+  defstruct [
+    :type,
+    :payload,
+    :text
+  ]
+
+  @doc """
+  Converts a keyword list of parameters to a list of structs
+  """
+  @spec parse(Keyword.t()) :: [__MODULE__.t()]
+  def parse([_ | _] = params) do
+    Enum.reduce_while(params, [], fn param, acc ->
+      case parse(param) do
+        %__MODULE__{} = parsed_param ->
+          {:cont, [parsed_param | acc]}
+
+        {:invalid_param, invalid_param} ->
+          {:halt, {:error, "Invalid button param: #{inspect(invalid_param)}"}}
+      end
+    end)
+  end
+
+  def parse({:payload, payload}) when is_binary(payload) or is_map(payload) do
+    %__MODULE__{type: :payload, payload: payload}
+  end
+
+  def parse({:text, text}) when is_binary(text) do
+    %__MODULE__{type: :text, text: text}
+  end
+
+  def parse(param) do
+    {:invalid_param, param}
+  end
+
+  @doc """
+  Validates parameter data
+  """
+  @spec validate({atom(), term()}) :: :ok | {:error, String.t()}
+  def validate({:payload, payload}) when is_binary(payload) or is_map(payload) do
+    :ok
+  end
+
+  def validate({:text, text}) when is_binary(text) do
+    :ok
+  end
+end

--- a/lib/messages/templates/component.ex
+++ b/lib/messages/templates/component.ex
@@ -1,0 +1,101 @@
+defmodule Wax.Messages.Templates.Component do
+  @moduledoc """
+  Template Components structure and management
+  """
+
+  alias Wax.Messages.Templates.{ButtonParameter, Parameter}
+
+  @type component_type :: :header | :body | :button
+  @type button_type :: :catalog | :quick_reply | :url
+
+  @type t :: %__MODULE__{
+          type: component_type(),
+          sub_type: button_type(),
+          parameters: [Parameter.t()],
+          index: 0..9
+        }
+
+  @valid_button_types [:quick_reply, :url, :catalog]
+
+  @derive {Jason.Encoder, only: [:type, :sub_type, :parameters, :index]}
+  defstruct [
+    :type,
+    :sub_type,
+    {:parameters, []},
+    :index
+  ]
+
+  @doc """
+  Creats a new Header Component struct
+  """
+  @spec new_header([Parameter.t()]) :: __MODULE__.t()
+  def new_header(params) do
+    %__MODULE__{type: :header, parameters: params}
+  end
+
+  @doc """
+  Creats a new Body Component struct
+  """
+  @spec new_body([Parameter.t()]) :: __MODULE__.t()
+  def new_body(params) do
+    %__MODULE__{type: :body, parameters: params}
+  end
+
+  @doc """
+  Creats a new Button Component struct
+  """
+  @spec new_button(button_type(), 0..9, [Parameter.t()]) :: __MODULE__.t()
+  def new_button(sub_type, index, params) when sub_type in @valid_button_types do
+    %__MODULE__{type: :button, sub_type: sub_type, index: index, parameters: params}
+  end
+
+  @doc """
+  Validates that the button parameters follow the rules and
+  constraints of the Cloud API
+  """
+  @spec validate_button_params(button_type(), Keyword.t()) ::
+          :ok | {:error, String.t()}
+  def validate_button_params(:catalog, _params) do
+    {:error, "Catalog type parameter not supported"}
+  end
+
+  def validate_button_params(:quick_reply, [_ | _] = params) do
+    do_validate(params, [:payload])
+  end
+
+  def validate_button_params(:url, [_ | _] = params) do
+    do_validate(params, [:text])
+  end
+
+  @spec do_validate(Keyword.t(), [atom()]) :: :ok | {:error, String.t()}
+  defp do_validate(params, required_params) do
+    with :ok <- validate_required(params, required_params),
+         nil <- find_error_in_params(params) do
+      :ok
+    end
+  end
+
+  @spec validate_required(Keyword.t(), [atom()]) :: :ok | {:error, String.t()}
+  defp validate_required(params, required_params) do
+    all_params_exists? =
+      Enum.all?(required_params, fn required_param ->
+        Enum.any?(params, fn {param_name, _} -> param_name == required_param end)
+      end)
+
+    if all_params_exists? do
+      :ok
+    else
+      {:error, "Missing required parameters"}
+    end
+  end
+
+  @spec find_error_in_params(Keyword.t()) :: nil | {:error, String.t()}
+  defp find_error_in_params(params) do
+    Enum.find_value(params, fn param ->
+      case ButtonParameter.validate(param) do
+        {:error, error} -> {:error, error}
+        _ -> false
+      end
+    end)
+  end
+end

--- a/lib/messages/templates/language.ex
+++ b/lib/messages/templates/language.ex
@@ -1,0 +1,29 @@
+defmodule Wax.Messages.Templates.Language do
+  @moduledoc """
+    Defines the Template language structure
+
+    code: Is the language code in either `language` (en) or `language_locale` (en_ES) formats
+    policy: This is always "deterministic"
+
+  """
+
+  @type t :: %__MODULE__{
+          code: String.t(),
+          policy: String.t()
+        }
+
+  @derive {Jason.Encoder, only: [:code, :policy]}
+  @enforce_keys [:code, :policy]
+  defstruct [:code, :policy]
+
+  @doc """
+  Creates a new language struct
+  """
+  @spec new(String.t()) :: __MODULE__.t()
+  def new(code) do
+    %__MODULE__{
+      code: code,
+      policy: "deterministic"
+    }
+  end
+end

--- a/lib/messages/templates/parameter.ex
+++ b/lib/messages/templates/parameter.ex
@@ -1,6 +1,8 @@
 defmodule Wax.Messages.Templates.Parameter do
   @moduledoc """
   Template parameter struct
+
+  TODO: Support for currency and date time parameters
   """
 
   alias Wax.Messages.Media
@@ -9,7 +11,6 @@ defmodule Wax.Messages.Templates.Parameter do
   @type t :: %__MODULE__{
           type: parameter_type(),
           text: String.t(),
-          currency: Currency.t(),
           image: Media.t(),
           document: Media.t(),
           video: Media.t()
@@ -19,8 +20,6 @@ defmodule Wax.Messages.Templates.Parameter do
   defstruct [
     :type,
     :text,
-    :currency,
-    :date_time,
     :image,
     :document,
     :video
@@ -48,6 +47,14 @@ defmodule Wax.Messages.Templates.Parameter do
 
   def parse({:image, %Media{} = image}) do
     %__MODULE__{type: :image, image: image}
+  end
+
+  def parse({:document, %Media{} = image}) do
+    %__MODULE__{type: :document, image: image}
+  end
+
+  def parse({:video, %Media{} = image}) do
+    %__MODULE__{type: :video, image: image}
   end
 
   def parse(param) do

--- a/lib/messages/templates/parameter.ex
+++ b/lib/messages/templates/parameter.ex
@@ -1,0 +1,56 @@
+defmodule Wax.Messages.Templates.Parameter do
+  @moduledoc """
+  Template parameter struct
+  """
+
+  alias Wax.Messages.Media
+
+  @typep parameter_type :: :currency | :date_time | :document | :image | :text | :video
+  @type t :: %__MODULE__{
+          type: parameter_type(),
+          text: String.t(),
+          currency: Currency.t(),
+          image: Media.t(),
+          document: Media.t(),
+          video: Media.t()
+        }
+
+  @derive {Jason.Encoder, only: [:type, :text, :currency, :date_time, :image, :document, :video]}
+  defstruct [
+    :type,
+    :text,
+    :currency,
+    :date_time,
+    :image,
+    :document,
+    :video
+  ]
+
+  @doc """
+  Converts a keyword list of params to a list of structs
+  """
+  @spec parse(Keyword.t()) :: [__MODULE__.t()]
+  def parse([_ | _] = params) do
+    Enum.reduce_while(params, [], fn param, acc ->
+      case parse(param) do
+        %__MODULE__{} = parsed_param ->
+          {:cont, [parsed_param | acc]}
+
+        {:invalid_param, invalid_param} ->
+          {:halt, {:error, "Invalid param: #{inspect(invalid_param)}"}}
+      end
+    end)
+  end
+
+  def parse({:text, text}) when is_binary(text) do
+    %__MODULE__{type: :text, text: text}
+  end
+
+  def parse({:image, %Media{} = image}) do
+    %__MODULE__{type: :image, image: image}
+  end
+
+  def parse(param) do
+    {:invalid_param, param}
+  end
+end

--- a/lib/messages/templates/parameter.ex
+++ b/lib/messages/templates/parameter.ex
@@ -7,7 +7,7 @@ defmodule Wax.Messages.Templates.Parameter do
 
   alias Wax.Messages.Media
 
-  @typep parameter_type :: :currency | :date_time | :document | :image | :text | :video
+  @typep parameter_type :: :document | :image | :text | :video
   @type t :: %__MODULE__{
           type: parameter_type(),
           text: String.t(),
@@ -16,7 +16,7 @@ defmodule Wax.Messages.Templates.Parameter do
           video: Media.t()
         }
 
-  @derive {Jason.Encoder, only: [:type, :text, :currency, :date_time, :image, :document, :video]}
+  @derive {Jason.Encoder, only: [:type, :text, :image, :document, :video]}
   defstruct [
     :type,
     :text,


### PR DESCRIPTION
## Contexto

Necesitamos migrar el envío de mensajes de tipo template (AKA HSM) para la nueva Cloud API.

## Changelog

### Builder para templates

Se agrega una API tipo builder, igual que la de Messages, para templates. Esto crea una estructura `Wax.Messages.Template` que usaremos después pare enviar el mensaje.

#### Parámetros

Los parámetros de los componentes de los templates se manejan como un Keyword list. Para ver que parámetros se aceptan para cada tipo de Component ver la documentación en `Wax.Messages.Template`

```elixir
  header_params = [
    {:image, MediaManager.new_image(media_id)}
  ]

  body_params = [
    {:text, "Mr. Test"}
  ]

  url_button_params = [
    {:text, "some_url_suffix"}
  ]

  quick_reply_button_params = [
     {:payload, "{\"TEST\": \"TESTING\"}"}
  ]

  template_name
  |> Template.new(language)
  |> Template.add_header(header_params)
  |> Template.add_body(body_params)
  |> Template.add_button(:url, 0, url_button_params)
  |> Template.add_button(:quick_reply, 1, quick_reply_button_params)

```

### Envío de mensajes tipo template

Una vez que ya se tiene el template creado se puede agregar al mensaje usando `Wax.Messages.Message.add_template/2`

```elixir
## `template` es el template que creamos en la sección anterior

message = 
  "55000000000"
  |> Message.new()
  |> Message.set_type(:template)
  |> Message.add_template(template)

auth = Auth.new("WHATSAPP_NUMBER_ID", "WHATSAPP_TOKEN")

iex> Messages.send(message, auth)
:ok
```

<img width="1170" height="1432" alt="image" src="https://github.com/user-attachments/assets/37b6e988-df2e-4a3d-bea9-784ddd13bad5" />


