### PR TITLE
Migrar envio de mensajes interactivos

### DIFF
--- a/lib/cloud_api/response_parser.ex
+++ b/lib/cloud_api/response_parser.ex
@@ -33,6 +33,15 @@ defmodule Wax.CloudAPI.ResponseParser do
     {:error, "Cloud API Error #{error_code}: #{error}"}
   end
 
+  def parse(
+        %Response{
+          body: %{"error" => %{"code" => error_code, "type" => type, "message" => message}}
+        },
+        _type
+      ) do
+    {:error, "Cloud API Error #{error_code} [#{type}]: #{message}"}
+  end
+
   def parse(%Response{status_code: status_code, body: body}, _type) do
     {:error, "HTTP Error #{status_code}: #{inspect(body)}"}
   end

--- a/lib/messages/interactive.ex
+++ b/lib/messages/interactive.ex
@@ -115,8 +115,10 @@ defmodule Wax.Messages.Interactive do
 
   """
   @spec put_product_action(__MODULE__.t(), String.t(), String.t()) :: __MODULE__.t()
-  def put_product_action(%__MODULE__{} = interactive, catalog_id, product_retailer_id) do
+  def put_product_action(%__MODULE__{} = interactive, catalog_id, product_retailer_id)
+      when is_binary(catalog_id) and is_binary(product_retailer_id) do
     action = %Action{
+      interactive_type: :product,
       catalog_id: catalog_id,
       product_retailer_id: product_retailer_id
     }

--- a/lib/messages/interactive.ex
+++ b/lib/messages/interactive.ex
@@ -102,4 +102,21 @@ defmodule Wax.Messages.Interactive do
 
     %{interactive | action: action}
   end
+
+  @doc """
+  Adds a product to the Interactive message
+
+  The product ID has to be a valid ID from your catalog only containing digits.
+
+  """
+  @spec put_product_action(__MODULE__.t(), String.t(), String.t()) :: __MODULE__.t()
+  def put_product_action(%__MODULE__{} = interactive, catalog_id, product_retailer_id) do
+    action = %Action{
+      interactive_type: interactive.type,
+      catalog_id: catalog_id,
+      product_retailer_id: product_retailer_id
+    }
+
+    %{interactive | action: action}
+  end
 end

--- a/lib/messages/interactive.ex
+++ b/lib/messages/interactive.ex
@@ -6,6 +6,9 @@ defmodule Wax.Messages.Interactive do
 
   Interactive messages of type `catalog_message` is not supported for lack
   of documentation on the Cloud API site. They can be added in the future.
+
+  TODO: Implement multi-product interactive messages
+
   """
 
   alias Wax.Messages.Interactive.{Action, Header, Section}
@@ -34,9 +37,9 @@ defmodule Wax.Messages.Interactive do
   @doc """
   Creates a new interactive object
   """
-  @spec new(type()) :: __MODULE__.t()
-  def new(type) when type in @interactive_types do
-    %__MODULE__{type: type}
+  @spec new() :: __MODULE__.t()
+  def new() do
+    %__MODULE__{}
   end
 
   @doc """
@@ -86,8 +89,8 @@ defmodule Wax.Messages.Interactive do
         %{type: :reply, reply: %{title: button_title, id: index}}
       end)
 
-    action = %Action{interactive_type: interactive.type, buttons: buttons}
-    %{interactive | action: action}
+    action = %Action{interactive_type: :button, buttons: buttons}
+    %{interactive | type: :button, action: action}
   end
 
   @doc """
@@ -98,9 +101,9 @@ defmodule Wax.Messages.Interactive do
 
   """
   def put_list_action(%__MODULE__{} = interactive, button_text, [%Section{} | _] = sections) do
-    action = %Action{interactive_type: interactive.type, button: button_text, sections: sections}
+    action = %Action{interactive_type: :list, button: button_text, sections: sections}
 
-    %{interactive | action: action}
+    %{interactive | type: :list, action: action}
   end
 
   @doc """
@@ -112,11 +115,13 @@ defmodule Wax.Messages.Interactive do
   @spec put_product_action(__MODULE__.t(), String.t(), String.t()) :: __MODULE__.t()
   def put_product_action(%__MODULE__{} = interactive, catalog_id, product_retailer_id) do
     action = %Action{
-      interactive_type: interactive.type,
+      interactive_type: :product,
       catalog_id: catalog_id,
       product_retailer_id: product_retailer_id
     }
 
+    %{interactive | type: :product, action: action}
+  end
     %{interactive | action: action}
   end
 end

--- a/lib/messages/interactive.ex
+++ b/lib/messages/interactive.ex
@@ -8,7 +8,7 @@ defmodule Wax.Messages.Interactive do
   of documentation on the Cloud API site. They can be added in the future.
   """
 
-  alias Wax.Messages.Interactive.{Action, Header}
+  alias Wax.Messages.Interactive.{Action, Header, Section}
 
   @type type :: :button | :list | :product | :product_list | :flow
 
@@ -73,7 +73,7 @@ defmodule Wax.Messages.Interactive do
   @doc """
   Adds a list of buttons to the Interactive message
 
-  The `buttons` paramater is expected to be a list of strings where each element
+  The `buttons` argument is expected to be a list of strings where each element
   will be the title (content) of the button.
 
   """
@@ -87,6 +87,19 @@ defmodule Wax.Messages.Interactive do
       end)
 
     action = %Action{interactive_type: interactive.type, buttons: buttons}
+    %{interactive | action: action}
+  end
+
+  @doc """
+  Adds a list to the Interactive message
+
+  The `sections` argument requires a list of %Section{} structs that can be constructed
+  using the Wax.Messages.Interactive.Section module
+
+  """
+  def put_list_action(%__MODULE__{} = interactive, button_text, [%Section{} | _] = sections) do
+    action = %Action{interactive_type: interactive.type, button: button_text, sections: sections}
+
     %{interactive | action: action}
   end
 end

--- a/lib/messages/interactive.ex
+++ b/lib/messages/interactive.ex
@@ -1,4 +1,92 @@
 defmodule Wax.Messages.Interactive do
-  @type t :: %__MODULE__{}
-  defstruct []
+  @moduledoc """
+  Interactive Messages
+
+  ## Important
+
+  Interactive messages of type `catalog_message` is not supported for lack
+  of documentation on the Cloud API site. They can be added in the future.
+  """
+
+  alias Wax.Messages.Interactive.{Action, Header}
+
+  @type type :: :button | :list | :product | :product_list | :flow
+
+  @type t :: %__MODULE__{
+          action: term(),
+          body: map(),
+          footer: map(),
+          header: Header.t(),
+          type: type()
+        }
+
+  @interactive_types [:button, :list, :product, :product_list, :flow]
+
+  @derive Jason.Encoder
+  defstruct [
+    :action,
+    :body,
+    :footer,
+    :header,
+    :type
+  ]
+
+  @doc """
+  Creates a new interactive object
+  """
+  @spec new(type()) :: __MODULE__.t()
+  def new(type) when type in @interactive_types do
+    %__MODULE__{type: type}
+  end
+
+  @doc """
+  Sets the header of the Interactive message
+  """
+  @spec put_header(__MODULE__.t(), Header.type(), String.t() | Media.t(), String.t() | nil) ::
+          __MODULE__.t()
+  def put_header(%__MODULE__{} = interactive, type, content, sub_text \\ nil) do
+    header = Header.new_header(type, content, sub_text)
+
+    %{interactive | header: header}
+  end
+
+  @doc """
+  Sets the body of the Interactive message
+  """
+  @spec put_body(__MODULE__.t(), String.t()) :: __MODULE__.t()
+  def put_body(%__MODULE__{} = interactive, content) when is_binary(content) do
+    body = %{text: content}
+
+    %{interactive | body: body}
+  end
+
+  @doc """
+  Sets the footer of the Interactive message
+  """
+  @spec put_footer(__MODULE__.t(), String.t()) :: __MODULE__.t()
+  def put_footer(%__MODULE__{} = interactive, content) when is_binary(content) do
+    footer = %{text: content}
+
+    %{interactive | footer: footer}
+  end
+
+  @doc """
+  Adds a list of buttons to the Interactive message
+
+  The `buttons` paramater is expected to be a list of strings where each element
+  will be the title (content) of the button.
+
+  """
+  @spec put_button_action(__MODULE__.t(), [button_title :: String.t()]) :: __MODULE__.t()
+  def put_button_action(%__MODULE__{} = interactive, [_ | _] = buttons) do
+    buttons =
+      buttons
+      |> Enum.with_index()
+      |> Enum.map(fn {button_title, index} ->
+        %{type: :reply, reply: %{title: button_title, id: index}}
+      end)
+
+    action = %Action{interactive_type: interactive.type, buttons: buttons}
+    %{interactive | action: action}
+  end
 end

--- a/lib/messages/interactive.ex
+++ b/lib/messages/interactive.ex
@@ -79,6 +79,8 @@ defmodule Wax.Messages.Interactive do
   The `buttons` argument is expected to be a list of strings where each element
   will be the title (content) of the button.
 
+  A max of 3 buttons can be sent.
+
   """
   @spec put_button_action(__MODULE__.t(), [button_title :: String.t()]) :: __MODULE__.t()
   def put_button_action(%__MODULE__{} = interactive, [_ | _] = buttons) do

--- a/lib/messages/interactive/action.ex
+++ b/lib/messages/interactive/action.ex
@@ -44,10 +44,10 @@ defmodule Wax.Messages.Interactive.Action do
       fields =
         case Map.get(value, :interactive_type) do
           :button ->
-            [:button, :buttons]
+            [:buttons]
 
           :list ->
-            [:sections]
+            [:button, :sections]
 
           :product ->
             [:catalog_id, :product_retailer_id]

--- a/lib/messages/interactive/action.ex
+++ b/lib/messages/interactive/action.ex
@@ -12,14 +12,8 @@ defmodule Wax.Messages.Interactive.Action do
           catalog_id: String.t(),
           product_retailer_id: String.t(),
           sections: [Section.t()],
-          flow_message_version: 3,
-          flow_id: String.t(),
-          flow_name: String.t(),
-          flow_cta: String.t(),
-          mode: String.t(),
-          flow_token: String.t(),
-          flow_action: String.t(),
-          flow_action_payload: String.t()
+          name: String.t(),
+          parameters: String.t()
         }
 
   defstruct [
@@ -29,14 +23,8 @@ defmodule Wax.Messages.Interactive.Action do
     :catalog_id,
     :product_retailer_id,
     :sections,
-    {:flow_message_version, 3},
-    :flow_id,
-    :flow_name,
-    :flow_cta,
-    :mode,
-    :flow_token,
-    :flow_action,
-    :flow_action_payload
+    :name,
+    :parameters
   ]
 
   defimpl Jason.Encoder do
@@ -56,16 +44,7 @@ defmodule Wax.Messages.Interactive.Action do
             [:catalog_id, :product_retailer_id, :sections]
 
           :flow ->
-            [
-              :flow_message_version,
-              :flow_id,
-              :flow_name,
-              :flow_cta,
-              :mode,
-              :flow_token,
-              :flow_action,
-              :flow_action_payload
-            ]
+            [:name, :parameters]
         end
 
       value

--- a/lib/messages/interactive/action.ex
+++ b/lib/messages/interactive/action.ex
@@ -1,0 +1,76 @@
+defmodule Wax.Messages.Interactive.Action do
+  @doc """
+  Interactive Actions struct
+  """
+
+  alias Wax.Messages.Interactive
+
+  @type t :: %__MODULE__{
+          interactive_type: Interactive.type(),
+          button: String.t(),
+          buttons: [Button.t()],
+          catalog_id: String.t(),
+          product_retailer_id: String.t(),
+          sections: [Section.t()],
+          flow_message_version: 3,
+          flow_id: String.t(),
+          flow_name: String.t(),
+          flow_cta: String.t(),
+          mode: String.t(),
+          flow_token: String.t(),
+          flow_action: String.t(),
+          flow_action_payload: String.t()
+        }
+
+  defstruct [
+    :interactive_type,
+    :button,
+    :buttons,
+    :catalog_id,
+    :product_retailer_id,
+    :sections,
+    {:flow_message_version, 3},
+    :flow_id,
+    :flow_name,
+    :flow_cta,
+    :mode,
+    :flow_token,
+    :flow_action,
+    :flow_action_payload
+  ]
+
+  defimpl Jason.Encoder do
+    def encode(value, opts) do
+      fields =
+        case Map.get(value, :interactive_type) do
+          :button ->
+            [:button, :buttons]
+
+          :list ->
+            [:sections]
+
+          :product ->
+            [:catalog_id, :product_retailer_id]
+
+          :product_list ->
+            [:catalog_id, :product_retailer_id, :sections]
+
+          :flow ->
+            [
+              :flow_message_version,
+              :flow_id,
+              :flow_name,
+              :flow_cta,
+              :mode,
+              :flow_token,
+              :flow_action,
+              :flow_action_payload
+            ]
+        end
+
+      value
+      |> Map.take(fields)
+      |> Jason.Encode.map(opts)
+    end
+  end
+end

--- a/lib/messages/interactive/header.ex
+++ b/lib/messages/interactive/header.ex
@@ -1,0 +1,72 @@
+defmodule Wax.Messages.Interactive.Header do
+  alias Wax.Messages.Media
+
+  @type type :: :text | :document | :image | :video
+
+  @type t :: %__MODULE__{
+          document: Media.t(),
+          image: Media.t(),
+          text: String.t(),
+          sub_text: String.t(),
+          type: atom(),
+          video: Media.t()
+        }
+
+  defstruct [
+    :document,
+    :image,
+    :text,
+    :sub_text,
+    :type,
+    :video
+  ]
+
+  defimpl Jason.Encoder do
+    def encode(value, opts) do
+      fields = [:sub_text, :type]
+
+      fields =
+        case Map.get(value, :type) do
+          :document -> [:document | fields]
+          :image -> [:image | fields]
+          :video -> [:video | fields]
+          :text -> [:text | fields]
+        end
+
+      value
+      |> Map.take(fields)
+      |> Jason.Encode.map(opts)
+    end
+  end
+
+  @doc """
+    Creates a new header
+
+    Depending the type, it will require a binary content or a Media content
+
+    Requires binary:
+      - text
+
+    Requires media:
+      - document
+      - image
+      - video
+
+  """
+  @spec new_header(type(), String.t() | Media.t(), String.t()) :: __MODULE__.t()
+  def new_header(:text, text, sub_text) when is_binary(text) do
+    %__MODULE__{type: :text, text: text, sub_text: sub_text}
+  end
+
+  def new_header(:document, %Media{} = media, sub_text) do
+    %__MODULE__{type: :document, document: media, sub_text: sub_text}
+  end
+
+  def new_header(:image, %Media{} = media, sub_text) do
+    %__MODULE__{type: :image, image: media, sub_text: sub_text}
+  end
+
+  def new_header(:video, %Media{} = media, sub_text) do
+    %__MODULE__{type: :video, video: media, sub_text: sub_text}
+  end
+end

--- a/lib/messages/interactive/section.ex
+++ b/lib/messages/interactive/section.ex
@@ -1,0 +1,59 @@
+defmodule Wax.Messages.Interactive.Section do
+  @doc """
+  Interactive Actions sections struct
+  """
+
+  @type t :: %__MODULE__{
+          product_items: [map()],
+          rows: [map()],
+          title: String.t()
+        }
+
+  @max_title_length 24
+  @max_rows 10
+
+  @derive Jason.Encoder
+  defstruct [
+    :product_items,
+    {:rows, []},
+    :title
+  ]
+
+  @doc """
+  Creates a new Interactive Action Section object
+  """
+  @spec new :: __MODULE__.t()
+  def new do
+    %__MODULE__{}
+  end
+
+  @doc """
+  Sets the title for the Section
+  """
+  @spec put_title(Module.t(), String.t()) :: __MODULE__.t()
+  def put_title(%__MODULE__{} = section, title) do
+    if String.length(title) > @max_title_length do
+      raise "A Section title cannot have more than 24 characters"
+    end
+
+    %{section | title: title}
+  end
+
+  @doc """
+  Adds a row to the Section
+  """
+  @spec add_row(__MODULE__.t(), String.t(), String.t(), String.t()) :: __MODULE__.t()
+  def add_row(%__MODULE__{rows: rows} = section, row_id, row_title, row_description \\ nil) do
+    if Enum.count(rows) >= @max_rows do
+      raise "A Section cannot have more than 10 rows"
+    end
+
+    row = %{
+      id: row_id,
+      title: row_title,
+      description: row_description
+    }
+
+    %{section | rows: [row | rows]}
+  end
+end

--- a/lib/messages/interactive/section/row.ex
+++ b/lib/messages/interactive/section/row.ex
@@ -11,6 +11,10 @@ defmodule Wax.Messages.Interactive.Section.Row do
           description: String.t()
         }
 
+  @max_id_length 200
+  @max_title_length 24
+  @max_description_length 72
+
   @enforce_keys [:id, :title]
   defstruct [
     :id,
@@ -24,5 +28,31 @@ defmodule Wax.Messages.Interactive.Section.Row do
   @spec new(String.t(), String.t(), String.t()) :: __MODULE__.t()
   def new(id, title, description \\ nil) do
     %__MODULE__{id: id, title: title, description: description}
+  end
+
+  @doc """
+  Validates that the Row struct follows the Cloud API requirements
+  """
+  @spec validate(__MODULE__.t()) :: :ok | {:error, String.t()}
+  def validate(%__MODULE__{id: id, title: title, description: description}) do
+    cond do
+      title in [nil, ""] ->
+        {:error, "Row title is required"}
+
+      id in [nil, ""] ->
+        {:error, "Row ID is required"}
+
+      String.length(id) > @max_id_length ->
+        {:error, "Row ID cannot be longer than #{@max_title_length} characters"}
+
+      String.length(title) > @max_title_length ->
+        {:error, "Row title cannot be longer than #{@max_title_length} characters"}
+
+      String.length(description) > @max_description_length ->
+        {:error, "Row description cannot be longer than #{@max_title_length} characters"}
+
+      true ->
+        :ok
+    end
   end
 end

--- a/lib/messages/interactive/section/row.ex
+++ b/lib/messages/interactive/section/row.ex
@@ -15,6 +15,7 @@ defmodule Wax.Messages.Interactive.Section.Row do
   @max_title_length 24
   @max_description_length 72
 
+  @derive Jason.Encoder
   @enforce_keys [:id, :title]
   defstruct [
     :id,
@@ -48,7 +49,7 @@ defmodule Wax.Messages.Interactive.Section.Row do
       String.length(title) > @max_title_length ->
         {:error, "Row title cannot be longer than #{@max_title_length} characters"}
 
-      String.length(description) > @max_description_length ->
+      is_binary(description) and String.length(description) > @max_description_length ->
         {:error, "Row description cannot be longer than #{@max_title_length} characters"}
 
       true ->

--- a/lib/messages/interactive/section/row.ex
+++ b/lib/messages/interactive/section/row.ex
@@ -1,0 +1,28 @@
+defmodule Wax.Messages.Interactive.Section.Row do
+  @moduledoc """
+  A Section Row struct
+
+  It is used in Interactive type messages
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          title: String.t(),
+          description: String.t()
+        }
+
+  @enforce_keys [:id, :title]
+  defstruct [
+    :id,
+    :title,
+    :description
+  ]
+
+  @doc """
+  Creates a new section row object
+  """
+  @spec new(String.t(), String.t(), String.t()) :: __MODULE__.t()
+  def new(id, title, description \\ nil) do
+    %__MODULE__{id: id, title: title, description: description}
+  end
+end

--- a/lib/messages/message.ex
+++ b/lib/messages/message.ex
@@ -275,6 +275,25 @@ defmodule Wax.Messages.Message do
     end
   end
 
+  def validate(%__MODULE__{
+        type: :interactive,
+        interactive: %Interactive{
+          type: :product,
+          action: %Action{catalog_id: catalog_id, product_retailer_id: product_retailer_id}
+        }
+      }) do
+    valid_catalog_id? = is_binary(catalog_id) && catalog_id not in ["", nil]
+
+    valid_product_retailer_id? =
+      is_binary(product_retailer_id) && product_retailer_id not in ["", nil]
+
+    case {valid_catalog_id?, valid_product_retailer_id?} do
+      {false, _} -> {:error, "Invalid Catalog ID"}
+      {_, false} -> {:error, "Invalid Product Retailer ID"}
+      _ -> :ok
+    end
+  end
+
   def validate(%__MODULE__{type: :template, template: %Template{}}) do
     :ok
   end

--- a/lib/messages/message.ex
+++ b/lib/messages/message.ex
@@ -16,6 +16,8 @@ defmodule Wax.Messages.Message do
     Text
   }
 
+  alias Wax.Messages.Interactive.Action
+
   @typep whatsapp_media_id :: String.t()
 
   @typep message_type ::
@@ -230,8 +232,15 @@ defmodule Wax.Messages.Message do
     end
   end
 
-  def validate(%__MODULE__{type: :interactive, interactive: %Interactive{}}) do
-    :ok
+  def validate(%__MODULE__{
+        type: :interactive,
+        interactive: %Interactive{type: :button, action: %Action{buttons: buttons}}
+      }) do
+    if length(buttons) <= 3 do
+      :ok
+    else
+      {:error, "An interactive button type message cannot have more than 3 buttons"}
+    end
   end
 
   def validate(%__MODULE__{type: :template, template: %Template{}}) do
@@ -252,6 +261,10 @@ defmodule Wax.Messages.Message do
 
   def validate(%__MODULE__{type: :interactive}) do
     {:error, "Interactive field is required. Use add_interactive/2 to add one."}
+  end
+
+  def validate(%__MODULE__{type: :interactive, interactive: %Interactive{}}) do
+    {:error, "Interactive messages should have an action object"}
   end
 
   def validate(%__MODULE__{type: :template}) do

--- a/lib/messages/message.ex
+++ b/lib/messages/message.ex
@@ -87,6 +87,7 @@ defmodule Wax.Messages.Message do
           :audio -> [:audio | fields]
           :document -> [:document | fields]
           :image -> [:image | fields]
+          :interactive -> [:interactive | fields]
           :template -> [:template | fields]
           :video -> [:video | fields]
           _ -> [:text | fields]
@@ -157,6 +158,14 @@ defmodule Wax.Messages.Message do
   end
 
   @doc """
+  Adds an interactive object to the message
+  """
+  @spec add_interactive(__MODULE__.t(), Interactive.t()) :: __MODULE__.t()
+  def add_interactive(%__MODULE__{} = message, %Interactive{} = interactive) do
+    %{message | interactive: interactive}
+  end
+
+  @doc """
   Adds a template object to the message
   """
   @spec add_template(__MODULE__.t(), Template.t()) :: __MODULE__.t()
@@ -221,6 +230,10 @@ defmodule Wax.Messages.Message do
     end
   end
 
+  def validate(%__MODULE__{type: :interactive, interactive: %Interactive{}}) do
+    :ok
+  end
+
   def validate(%__MODULE__{type: :template, template: %Template{}}) do
     :ok
   end
@@ -235,6 +248,10 @@ defmodule Wax.Messages.Message do
 
   def validate(%__MODULE__{type: :document}) do
     {:error, "Document field is required. Use add_document/3 to add one."}
+  end
+
+  def validate(%__MODULE__{type: :interactive}) do
+    {:error, "Interactive field is required. Use add_interactive/2 to add one."}
   end
 
   def validate(%__MODULE__{type: :template}) do

--- a/lib/mix/tasks/send_message.ex
+++ b/lib/mix/tasks/send_message.ex
@@ -136,8 +136,7 @@ defmodule Mix.Tasks.SendMessage do
 
   defp build_test_message(message, "interactive", _params) do
     interactive =
-      :button
-      |> Interactive.new()
+      Interactive.new()
       |> Interactive.put_header(:text, "Header", "Subtexto")
       |> Interactive.put_body("BODY")
       |> Interactive.put_footer("This is a footer")
@@ -161,8 +160,7 @@ defmodule Mix.Tasks.SendMessage do
       |> Section.add_row("s21", "Testing", "Description")
 
     interactive =
-      :list
-      |> Interactive.new()
+      Interactive.new()
       |> Interactive.put_header(:text, "Header", "Subtexto")
       |> Interactive.put_body("BODY")
       |> Interactive.put_footer("This is a footer")
@@ -174,9 +172,10 @@ defmodule Mix.Tasks.SendMessage do
   end
 
   defp build_test_message(message, "interactive-product", _params) do
+    # You have to have a Catalog with products made on the Whatsapp Bussiness side
+
     interactive =
-      :product
-      |> Interactive.new()
+      Interactive.new()
       |> Interactive.put_body("BODY")
       |> Interactive.put_footer("This is a footer")
       |> Interactive.put_product_action("PRODUCT_ID", "bravo")

--- a/lib/mix/tasks/send_message.ex
+++ b/lib/mix/tasks/send_message.ex
@@ -173,6 +173,19 @@ defmodule Mix.Tasks.SendMessage do
     |> Message.add_interactive(interactive)
   end
 
+  defp build_test_message(message, "interactive-product", _params) do
+    interactive =
+      :product
+      |> Interactive.new()
+      |> Interactive.put_body("BODY")
+      |> Interactive.put_footer("This is a footer")
+      |> Interactive.put_product_action("PRODUCT_ID", "bravo")
+
+    message
+    |> Message.set_type(:interactive)
+    |> Message.add_interactive(interactive)
+  end
+
   defp build_test_message(message, "template", %{media_id: media_id}) do
     template_name = "test_url_and_image"
     language = "es_MX"

--- a/lib/mix/tasks/send_message.ex
+++ b/lib/mix/tasks/send_message.ex
@@ -26,6 +26,8 @@ defmodule Mix.Tasks.SendMessage do
   alias Wax.CloudAPI.{Auth, Messages}
   alias Wax.CloudAPI.Media, as: MediaManager
   alias Wax.Messages.{Interactive, Media, Message, Template}
+  alias Wax.Messages.Interactive
+  alias Wax.Messages.Interactive.Section
 
   use Mix.Task
 
@@ -140,6 +142,31 @@ defmodule Mix.Tasks.SendMessage do
       |> Interactive.put_body("BODY")
       |> Interactive.put_footer("This is a footer")
       |> Interactive.put_button_action(["First Button", "Second Button"])
+
+    message
+    |> Message.set_type(:interactive)
+    |> Message.add_interactive(interactive)
+  end
+
+  defp build_test_message(message, "interactive-list", _params) do
+    section_1 =
+      Section.new()
+      |> Section.put_title("Section 1 Title")
+      |> Section.add_row("row1", "Row 1 title", "This is a row with a description")
+      |> Section.add_row("row2", "Row 2 title")
+
+    section_2 =
+      Section.new()
+      |> Section.put_title("Section 2 Title")
+      |> Section.add_row("s21", "Testing", "Description")
+
+    interactive =
+      :list
+      |> Interactive.new()
+      |> Interactive.put_header(:text, "Header", "Subtexto")
+      |> Interactive.put_body("BODY")
+      |> Interactive.put_footer("This is a footer")
+      |> Interactive.put_list_action("A button?", [section_1, section_2])
 
     message
     |> Message.set_type(:interactive)

--- a/lib/mix/tasks/send_message.ex
+++ b/lib/mix/tasks/send_message.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.SendMessage do
 
   alias Wax.CloudAPI.{Auth, Messages}
   alias Wax.CloudAPI.Media, as: MediaManager
-  alias Wax.Messages.{Media, Message, Template}
+  alias Wax.Messages.{Interactive, Media, Message, Template}
 
   use Mix.Task
 
@@ -130,6 +130,20 @@ defmodule Mix.Tasks.SendMessage do
     message
     |> Message.set_type(:image)
     |> Message.add_image(media_id, "This is a caption")
+  end
+
+  defp build_test_message(message, "interactive", _params) do
+    interactive =
+      :button
+      |> Interactive.new()
+      |> Interactive.put_header(:text, "Header", "Subtexto")
+      |> Interactive.put_body("BODY")
+      |> Interactive.put_footer("This is a footer")
+      |> Interactive.put_button_action(["First Button", "Second Button"])
+
+    message
+    |> Message.set_type(:interactive)
+    |> Message.add_interactive(interactive)
   end
 
   defp build_test_message(message, "template", %{media_id: media_id}) do

--- a/lib/mix/tasks/send_message.ex
+++ b/lib/mix/tasks/send_message.ex
@@ -185,6 +185,21 @@ defmodule Mix.Tasks.SendMessage do
     |> Message.add_interactive(interactive)
   end
 
+  defp build_test_message(message, "interactive-flow", _params) do
+    # You have to have a Flow created on the Whatsapp Bussiness side
+
+    interactive =
+      Interactive.new()
+      |> Interactive.put_header(:text, "Header", "Subtexto")
+      |> Interactive.put_body("BODY")
+      |> Interactive.put_footer("This is a footer")
+      |> Interactive.put_flow_action("CTA Button", {:name, "some-flow"})
+
+    message
+    |> Message.set_type(:interactive)
+    |> Message.add_interactive(interactive)
+  end
+
   defp build_test_message(message, "template", %{media_id: media_id}) do
     template_name = "test_url_and_image"
     language = "es_MX"

--- a/lib/mix/tasks/send_message.ex
+++ b/lib/mix/tasks/send_message.ex
@@ -12,6 +12,11 @@ defmodule Mix.Tasks.SendMessage do
 
   An argument for the message type can be sent. Currently supported message types are:
   - text
+  - document
+  - image
+  - interactive
+  - template
+  - video
 
   The default message type is `text`
 


### PR DESCRIPTION
## Contexto

Necesitamos migrar el envío de mensajes interactivos para la nueva Cloud API.

## Changelog

### Builder para mensajes interactivos

Se agrega una API tipo builder, igual que la de Messages, para mensajes interactivos. Esto crea una estructura `Wax.Messages.Interactive` que usaremos después pare enviar el mensaje.

Así mismo se agrega un API igual para objetos de tipo Action (Wax.Messages.Interactive.Action) y Sections (Wax.Messages.Interactive.Section). 

```elixir
## Tipo flow
Interactive.new()
|> Interactive.put_header(:text, "Header", "Subtexto")
|> Interactive.put_body("BODY")
|> Interactive.put_footer("This is a footer")
|> Interactive.put_flow_action("FLOW_CTA", {:id, "TEST01490124"}, %{
  mode: :draft,
  flow_token: "TOKENTEST"
})




```

## Sections

Los mensajes interactivos de tipo lista requireren una lista de secciones. Estas las podemos construir con el API de `Wax.Messages.Interactive.Sections`.

```elixir
## Tipo lista
section =
  Section.new()
  |> Section.put_title("Section 1 Title")
  |> Section.add_row("row1", "Row 1 title", "This is a row with a description")
  |> Section.add_row("", "Row 2 title")

Interactive.new()
|> Interactive.put_header(:text, "Header", "Subtexto")
|> Interactive.put_body("BODY")
|> Interactive.put_footer("This is a footer")
|> Interactive.put_list_action("Button", [section])
```

### Envío de mensajes tipo template

Una vez que ya se tiene el mensaje interactivo creado se puede agregar al mensaje usando `Wax.Messages.Message.add_interactive/2`

```elixir
## `interactive` es el mensaje interactivo que creamos en la sección anterior

message = 
  "55000000000"
  |> Message.new()
  |> Message.set_type(:interactive)
  |> Message.add_template(interactive)

auth = Auth.new("WHATSAPP_NUMBER_ID", "WHATSAPP_TOKEN")

iex> Messages.send(message, auth)
:ok
```

## Ejemplos

![IMG_8235](https://github.com/user-attachments/assets/0a70bed3-6d1b-4e65-9cf8-de3fa858aa9a)

<img width="1170" height="2532" alt="IMG_8234" src="https://github.com/user-attachments/assets/6c5b5e96-61a0-43d2-8c21-e63dedab00a3" />



