### PR TITLE
Carga de archivos media por binario

### DIFF
--- a/lib/cloud_api/media.ex
+++ b/lib/cloud_api/media.ex
@@ -43,7 +43,8 @@ defmodule Wax.CloudAPI.Media do
     end
   end
 
-  # @spec do_upload(Path.t(), Auth.t()) :: {:ok, Media.media_id()} | {:error, String.t()}
+  @spec do_upload(Path.t() | iodata(), String.t(), String.t(), Auth.t()) ::
+          {:ok, Media.media_id()} | {:error, String.t()}
   defp do_upload(multipart_data, mime_type, filename, auth) do
     headers = [Auth.build_header(auth)]
 

--- a/lib/cloud_api/media.ex
+++ b/lib/cloud_api/media.ex
@@ -61,7 +61,7 @@ defmodule Wax.CloudAPI.Media do
       {:ok, response} ->
         ResponseParser.parse(response, :media_upload)
 
-      error ->
+      _ ->
         {:error, "Media upload failed"}
     end
   end

--- a/lib/mix/tasks/send_message.ex
+++ b/lib/mix/tasks/send_message.ex
@@ -92,7 +92,7 @@ defmodule Mix.Tasks.SendMessage do
   @spec upload_media_if_required(Auth.t(), map()) ::
           {:ok, map()} | {:error, String.t()}
   defp upload_media_if_required(auth, %{file_path: file_path} = params) do
-    case MediaManager.upload(file_path, auth) do
+    case MediaManager.upload_from_path(file_path, auth) do
       {:ok, media_id} ->
         {:ok, Map.put(params, :media_id, media_id)}
 

--- a/lib/whatsapp_api_base_request.ex
+++ b/lib/whatsapp_api_base_request.ex
@@ -37,6 +37,8 @@ defmodule WhatsappApiBaseRequest do
     apply(module, method, params)
   rescue
     reason ->
+      Logger.error("[Cloud API] : #{inspect(reason)}")
+
       Logger.info(
         "Got a HTTP Error, attempts #{attempts}",
         reason: inspect(reason),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule WhatsappApi.MixProject do
     [
       app: :wax,
       elixirc_paths: elixirc_paths(Mix.env()),
-      version: "1.0.1",
+      version: "1.1.0",
       description: "Whatsapp Elixir Client",
       elixir: "~> 1.16",
       package: package(),

--- a/test/cloud_api/media_test.exs
+++ b/test/cloud_api/media_test.exs
@@ -24,15 +24,15 @@ defmodule Wax.CloudAPI.MediaTest do
       Plug.Conn.resp(conn, 200, response)
     end)
 
-    test_file = Briefly.create!(extname: ".pdf")
+    test_file_path = Briefly.create!(extname: ".pdf")
 
-    assert {:ok, ^media_id} = Media.upload_from_path(test_file, auth)
+    assert {:ok, ^media_id} = Media.upload_from_path(test_file_path, auth)
   end
 
   test "Uploading a document with no extension should return an error", %{auth: auth} do
-    test_file = Briefly.create!(extname: "")
+    test_file_path = Briefly.create!(extname: "")
 
-    assert {:error, error} = Media.upload_from_path(test_file, auth)
+    assert {:error, error} = Media.upload_from_path(test_file_path, auth)
     assert String.contains?(error, "extension")
   end
 
@@ -44,19 +44,19 @@ defmodule Wax.CloudAPI.MediaTest do
       Plug.Conn.resp(conn, 200, response)
     end)
 
-    test_file = Briefly.create!(extname: ".pdf")
-    binary_data = File.read!(test_file)
+    test_file_path = Briefly.create!(extname: ".pdf")
+    binary_data = File.read!(test_file_path)
 
-    assert {:ok, ^media_id} = Media.upload_binary(binary_data, test_file, auth)
+    assert {:ok, ^media_id} = Media.upload_binary(binary_data, test_file_path, auth)
   end
 
   test "Uploading a document from a binary with no extension should return an error", %{
     auth: auth
   } do
-    test_file = Briefly.create!(extname: "")
-    binary_data = File.read!(test_file)
+    test_file_path = Briefly.create!(extname: "")
+    binary_data = File.read!(test_file_path)
 
-    assert {:error, error} = Media.upload_binary(binary_data, test_file, auth)
+    assert {:error, error} = Media.upload_binary(binary_data, test_file_path, auth)
     assert String.contains?(error, "extension")
   end
 end

--- a/test/cloud_api/media_test.exs
+++ b/test/cloud_api/media_test.exs
@@ -26,13 +26,13 @@ defmodule Wax.CloudAPI.MediaTest do
 
     test_file = Briefly.create!(extname: ".pdf")
 
-    assert {:ok, ^media_id} = Media.upload(test_file, auth)
+    assert {:ok, ^media_id} = Media.upload_from_path(test_file, auth)
   end
 
   test "Uploading a document with no extension should return an error", %{auth: auth} do
     test_file = Briefly.create!(extname: "")
 
-    assert {:error, error} = Media.upload(test_file, auth)
+    assert {:error, error} = Media.upload_from_path(test_file, auth)
     assert String.contains?(error, "extension")
   end
 end

--- a/test/cloud_api/media_test.exs
+++ b/test/cloud_api/media_test.exs
@@ -35,4 +35,28 @@ defmodule Wax.CloudAPI.MediaTest do
     assert {:error, error} = Media.upload_from_path(test_file, auth)
     assert String.contains?(error, "extension")
   end
+
+  test "Upload a document file from a binary", %{bypass: bypass, auth: auth} do
+    media_id = "TEST00000000"
+
+    Bypass.expect_once(bypass, "POST", "/#{auth.whatsapp_number_id}/media", fn conn ->
+      response = ~s<{"id": "#{media_id}"}>
+      Plug.Conn.resp(conn, 200, response)
+    end)
+
+    test_file = Briefly.create!(extname: ".pdf")
+    binary_data = File.read!(test_file)
+
+    assert {:ok, ^media_id} = Media.upload_binary(binary_data, test_file, auth)
+  end
+
+  test "Uploading a document from a binary with no extension should return an error", %{
+    auth: auth
+  } do
+    test_file = Briefly.create!(extname: "")
+    binary_data = File.read!(test_file)
+
+    assert {:error, error} = Media.upload_binary(binary_data, test_file, auth)
+    assert String.contains?(error, "extension")
+  end
 end

--- a/test/cloud_api/messages_test.exs
+++ b/test/cloud_api/messages_test.exs
@@ -65,7 +65,7 @@ defmodule Wax.CloudAPI.MessagesTest do
       {:ok, media_id} =
         [extname: ".png"]
         |> Briefly.create!()
-        |> Media.upload(auth)
+        |> Media.upload_from_path(auth)
 
       Bypass.expect(bypass, "POST", "/#{auth.whatsapp_number_id}/messages", fn conn ->
         response = ~s<{"messaging_product": "whatsapp", "messages": [{"id": "TESTMESSAGEID"}]}>
@@ -99,7 +99,7 @@ defmodule Wax.CloudAPI.MessagesTest do
       {:ok, media_id} =
         [extname: ".mp4"]
         |> Briefly.create!()
-        |> Media.upload(auth)
+        |> Media.upload_from_path(auth)
 
       Bypass.expect(bypass, "POST", "/#{auth.whatsapp_number_id}/messages", fn conn ->
         response = ~s<{"messaging_product": "whatsapp", "messages": [{"id": "TESTMESSAGEID"}]}>
@@ -133,7 +133,7 @@ defmodule Wax.CloudAPI.MessagesTest do
       {:ok, media_id} =
         [extname: ".mp3"]
         |> Briefly.create!()
-        |> Media.upload(auth)
+        |> Media.upload_from_path(auth)
 
       Bypass.expect(bypass, "POST", "/#{auth.whatsapp_number_id}/messages", fn conn ->
         response = ~s<{"messaging_product": "whatsapp", "messages": [{"id": "TESTMESSAGEID"}]}>
@@ -160,7 +160,7 @@ defmodule Wax.CloudAPI.MessagesTest do
       {:ok, media_id} =
         [extname: ".pdf"]
         |> Briefly.create!()
-        |> Media.upload(auth)
+        |> Media.upload_from_path(auth)
 
       Bypass.expect(bypass, "POST", "/#{auth.whatsapp_number_id}/messages", fn conn ->
         response = ~s<{"messaging_product": "whatsapp", "messages": [{"id": "TESTMESSAGEID"}]}>
@@ -196,7 +196,7 @@ defmodule Wax.CloudAPI.MessagesTest do
       {:ok, media_id} =
         [extname: ".png"]
         |> Briefly.create!()
-        |> Media.upload(auth)
+        |> Media.upload_from_path(auth)
 
       Bypass.expect(bypass, "POST", "/#{auth.whatsapp_number_id}/messages", fn conn ->
         response = ~s<{"messaging_product": "whatsapp", "messages": [{"id": "TESTMESSAGEID"}]}>


### PR DESCRIPTION
## Contexto

Para evitar lecturas extras de disco, se agrega una opción para subir archivos media recibiendo la data en binario.

## Changelog
- Removes `Wax.CloudAPI.Media.upload/2`
- Adds `Wax.CloudAPI.Media.upload_from_path/2`
- Adds `Wax.CloudAPI.Media.upload_binary/3`