### PR TITLE
Agregar soporte para descarga de archivos media desde Cloud API

### DIFF
--- a/lib/cloud_api.ex
+++ b/lib/cloud_api.ex
@@ -8,12 +8,22 @@ defmodule Wax.CloudAPI do
   """
   @spec build_url(String.t(), String.t()) :: String.t()
   def build_url(whatsapp_number_id, endpoint) do
+    whatsapp_number_id
+    |> Path.join(endpoint)
+    |> do_build_url()
+  end
+
+  def build_url(endpoint) do
+    do_build_url(endpoint)
+  end
+
+  defp do_build_url(endpoint) do
     config = Application.get_env(:wax, :cloud_api)
     url = config[:url]
     api_version = config[:api_version]
 
     url
-    |> URI.merge("#{api_version}/#{whatsapp_number_id}/#{endpoint}")
+    |> URI.merge("#{api_version}/#{endpoint}")
     |> URI.to_string()
   end
 end

--- a/lib/cloud_api/media.ex
+++ b/lib/cloud_api/media.ex
@@ -9,6 +9,8 @@ defmodule Wax.CloudAPI.Media do
   @doc """
   Downloads a media file from the Whatsapp Cloud server
   """
+  @spec download(String.t(), Auth.t()) ::
+          {:ok, file_binary_data :: binary()} | {:error, String.t()}
   def download(media_id, %Auth{} = auth) do
     with {:ok, media_url} <- get_media_url(media_id, auth) do
       download_media(media_url, auth)

--- a/lib/cloud_api/media.ex
+++ b/lib/cloud_api/media.ex
@@ -46,9 +46,11 @@ defmodule Wax.CloudAPI.Media do
     end
   end
 
+  @doc """
+  Uploads a media file to the Cloud API servers from a path
+
   This returns the Media ID, which is required to send any type
   of media files in a message.
-
   """
   @spec upload_from_path(Path.t(), Auth.t()) ::
           {:ok, Media.media_id()} | {:error, String.t()}
@@ -57,7 +59,7 @@ defmodule Wax.CloudAPI.Media do
   end
 
   @doc """
-  Uploads an image to the Cloud API servers from binary data
+  Uploads a media file to the Cloud API servers from binary data
 
   This returns the Media ID, which is required to send any type
   of media files in a message.

--- a/lib/cloud_api/media.ex
+++ b/lib/cloud_api/media.ex
@@ -51,6 +51,7 @@ defmodule Wax.CloudAPI.Media do
 
   This returns the Media ID, which is required to send any type
   of media files in a message.
+
   """
   @spec upload_from_path(Path.t(), Auth.t()) ::
           {:ok, Media.media_id()} | {:error, String.t()}

--- a/lib/cloud_api/media.ex
+++ b/lib/cloud_api/media.ex
@@ -7,7 +7,44 @@ defmodule Wax.CloudAPI.Media do
   alias Wax.CloudAPI.{Auth, ResponseParser}
 
   @doc """
-  Uploads an image to the Cloud API servers from the given path
+  Downloads a media file from the Whatsapp Cloud server
+  """
+  def download(media_id, %Auth{} = auth) do
+    with {:ok, media_url} <- get_media_url(media_id, auth) do
+      download_media(media_url, auth)
+    end
+  end
+
+  @spec get_media_url(String.t(), Auth.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defp get_media_url(media_id, auth) do
+    headers = [Auth.build_header(auth)]
+
+    media_id
+    |> CloudAPI.build_url()
+    |> HTTPoison.get(headers)
+    |> case do
+      {:ok, response} ->
+        ResponseParser.parse(response, :media_data)
+
+      {:error, error} ->
+        {:error, "Obtaining media URL failed: #{inspect(error)}"}
+    end
+  end
+
+  @spec download_media(String.t(), Auth.t()) :: {:ok, term()} | {:error, String.t()}
+  defp download_media(media_url, auth) do
+    headers = [Auth.build_header(auth)]
+
+    media_url
+    |> HTTPoison.get(headers)
+    |> case do
+      {:ok, response} ->
+        ResponseParser.parse(response, :media_download)
+
+      {:error, error} ->
+        {:error, "Media download failed: #{inspect(error)}"}
+    end
+  end
 
   This returns the Media ID, which is required to send any type
   of media files in a message.

--- a/lib/cloud_api/response_parser.ex
+++ b/lib/cloud_api/response_parser.ex
@@ -20,6 +20,23 @@ defmodule Wax.CloudAPI.ResponseParser do
     end
   end
 
+  def parse(%Response{status_code: 200, body: body}, :media_data) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, %{"url" => media_url}} ->
+        {:ok, media_url}
+
+      {:ok, %{"error" => %{"message" => error_message}}} ->
+        {:error, "Media not found: #{error_message}"}
+
+      _ ->
+        {:error, "Unexpected error when downloading file: #{body}"}
+    end
+  end
+
+  def parse(%Response{status_code: 200, body: body}, :media_download) when is_bitstring(body) do
+    {:ok, body}
+  end
+
   def parse(%Response{status_code: 200, body: body}, _type) do
     {:ok, body}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule WhatsappApi.MixProject do
     [
       app: :wax,
       elixirc_paths: elixirc_paths(Mix.env()),
-      version: "1.1.1",
+      version: "1.1.2",
       description: "Whatsapp Elixir Client",
       elixir: "~> 1.16",
       package: package(),

--- a/test/cloud_api/media_test.exs
+++ b/test/cloud_api/media_test.exs
@@ -16,6 +16,24 @@ defmodule Wax.CloudAPI.MediaTest do
     {:ok, bypass: bypass, auth: auth, to: test_to_number}
   end
 
+  test "Downloading a media file", %{bypass: bypass, auth: auth} do
+    url = "localhost:#{bypass.port}/test-download-media"
+    media_id = "TEST00000000"
+
+    Bypass.expect_once(bypass, "GET", "/#{media_id}", fn conn ->
+      response = ~s<{"url": "#{url}"}>
+      Plug.Conn.resp(conn, 200, response)
+    end)
+
+    Bypass.expect_once(bypass, "GET", "/test-download-media", fn conn ->
+      response = <<0>>
+      Plug.Conn.resp(conn, 200, response)
+    end)
+
+    assert {:ok, binary_data} = Media.download(media_id, auth)
+    assert is_bitstring(binary_data)
+  end
+
   test "Upload a document file", %{bypass: bypass, auth: auth} do
     media_id = "TEST00000000"
 


### PR DESCRIPTION
## Contexto

No existía el API para descargar archivos media desde Cloud API.

## Changelog

- Se agrega `Wax.CloudAPI.Media.download/2` para descargar archivos usando el `media_id`.